### PR TITLE
【安全漏洞】秘钥文件文件mode应该为0600

### DIFF
--- a/src/qshell/account.go
+++ b/src/qshell/account.go
@@ -7,6 +7,7 @@ import (
 	"github.com/astaxie/beego/logs"
 	"io/ioutil"
 	"os"
+	"syscall"
 	"path/filepath"
 )
 
@@ -40,7 +41,10 @@ func SetAccount(accessKey string, secretKey string) (err error) {
 
 	accountFname := filepath.Join(storageDir, "account.json")
 
-	accountFh, openErr := os.Create(accountFname)
+	accountFh, openErr := os.OpenFile(accountFname,
+		syscall.O_WRONLY|syscall.O_CREATE|syscall.O_TRUNC,
+		0600,
+	)
 	if openErr != nil {
 		err = fmt.Errorf("Open account file error, %s", openErr)
 		return


### PR DESCRIPTION
尽管目前secret key是加密的格式，但是加密解密的机制和salt都是公开的，所以并不能阻止系统其他用户拿到secret key。秘钥文件的创建不能依赖于umask来限制权限，必须强制将权限设置为0600