### PR TITLE
bilibili ,put host config in account.conf

### DIFF
--- a/src/qshell/account.go
+++ b/src/qshell/account.go
@@ -4,10 +4,11 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/astaxie/beego/logs"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"github.com/astaxie/beego/logs"
 )
 
 type Account struct {
@@ -104,12 +105,7 @@ func GetAccount() (account Account, err error) {
 	}
 
 	// backwards compatible with old version of qshell, which encrypt ak/sk based on existing ak/sk
-	if len(account.SecretKey) == 40 {
-		setErr := SetAccount(account.AccessKey, account.SecretKey)
-		if setErr != nil {
-			return
-		}
-	} else {
+	if len(account.SecretKey) != 40 {
 		aesKey := Md5Hex(account.AccessKey)
 		encryptedSecretKeyBytes, decodeErr := base64.URLEncoding.DecodeString(account.SecretKey)
 		if decodeErr != nil {


### PR DESCRIPTION
和主分支不完全兼容，提交作为一个记录，不用合并。

B 客户使用，-c config.conf  指定 account 、 host 信息；不加密；
主分支： -c account.conf  指定 account ， -f host.conf 获取 host 信息，对 account.conf  中 sk 加密保存；

和主分支不完全兼容，提交作为一个记录，不用合并。
