### PR TITLE
support public bucket for qdownload

### DIFF
--- a/docs/qdownload.md
+++ b/docs/qdownload.md
@@ -38,6 +38,7 @@ qshell qdownload [-c <ThreadCount>] <LocalDownloadConfig>
     "suffixes"   :   ".png,.jpg",
     "cdn_domain" :   "down.example.com",
     "referer"    :   "http://www.example.com",
+    "use_https"   :  true,
     "public"     :   true,
     "log_file"   :   "download.log",
     "log_level"  :   "info",
@@ -54,6 +55,7 @@ qshell qdownload [-c <ThreadCount>] <LocalDownloadConfig>
 |suffixes|只同步指定后缀的文件，默认为空|Y|
 |cdn_domain|设置下载的CDN域名，默认为空表示从存储源站下载，【该功能默认需要计费，如果希望享受10G的免费流量，请自行设置cdn_domain参数，如不设置，需支付源站流量费用，无法减免！！！】|N|
 |referer|如果CDN域名配置了域名白名单防盗链，需要指定一个允许访问的referer地址|N|
+|use_https|设置下载的CDN域名是否是使用 HTTPS 协议
 |public|空间为公开空间，下载时不会对下载 URL 进行签名，可以提升CDN域名性能，默认为私有空间|N|
 |log_level|下载日志输出级别，可选值为`debug`,`info`,`warn`,`error`,默认`info`|Y|
 |log_file|下载日志的输出文件，如果不指定会输出到qshell工作目录下默认的文件中，文件名可以在终端输出看到|Y|

--- a/docs/qdownload.md
+++ b/docs/qdownload.md
@@ -38,6 +38,7 @@ qshell qdownload [-c <ThreadCount>] <LocalDownloadConfig>
     "suffixes"   :   ".png,.jpg",
     "cdn_domain" :   "down.example.com",
     "referer"    :   "http://www.example.com",
+    "public"     :   true,
     "log_file"   :   "download.log",
     "log_level"  :   "info",
     "log_rotate" :   1,
@@ -53,6 +54,7 @@ qshell qdownload [-c <ThreadCount>] <LocalDownloadConfig>
 |suffixes|只同步指定后缀的文件，默认为空|Y|
 |cdn_domain|设置下载的CDN域名，默认为空表示从存储源站下载，【该功能默认需要计费，如果希望享受10G的免费流量，请自行设置cdn_domain参数，如不设置，需支付源站流量费用，无法减免！！！】|N|
 |referer|如果CDN域名配置了域名白名单防盗链，需要指定一个允许访问的referer地址|N|
+|public|空间为公开空间，下载时不会对下载 URL 进行签名，可以提升CDN域名性能，默认为私有空间|N|
 |log_level|下载日志输出级别，可选值为`debug`,`info`,`warn`,`error`,默认`info`|Y|
 |log_file|下载日志的输出文件，如果不指定会输出到qshell工作目录下默认的文件中，文件名可以在终端输出看到|Y|
 |log_rotate|下载日志文件的切换周期，单位为天，默认为1天即切换到新的下载日志文件|Y|

--- a/iqshell/bucket.go
+++ b/iqshell/bucket.go
@@ -93,6 +93,13 @@ func (m *BucketManager) DomainsOfBucket(bucket string) (domains []string, err er
 	return
 }
 
+// 返回公有空间的下载链接，不可以用于私有空间的下载
+func (m *BucketManager) MakePublicDownloadLink(domainOfBucket, fileKey string) (fileUrl string) {
+
+	fileUrl = fmt.Sprintf("http://%s/%s", domainOfBucket, url.PathEscape(fileKey))
+	return
+}
+
 // 返回私有空间的下载链接， 也可以用于公有空间的下载
 func (m *BucketManager) MakePrivateDownloadLink(domainOfBucket, fileKey string) (fileUrl string) {
 

--- a/iqshell/bucket.go
+++ b/iqshell/bucket.go
@@ -94,16 +94,23 @@ func (m *BucketManager) DomainsOfBucket(bucket string) (domains []string, err er
 }
 
 // 返回公有空间的下载链接，不可以用于私有空间的下载
-func (m *BucketManager) MakePublicDownloadLink(domainOfBucket, fileKey string) (fileUrl string) {
-
-	fileUrl = fmt.Sprintf("http://%s/%s", domainOfBucket, url.PathEscape(fileKey))
+func (m *BucketManager) MakePublicDownloadLink(domainOfBucket, fileKey string, useHttps bool) (fileUrl string) {
+	if useHttps {
+		fileUrl = fmt.Sprintf("https://%s/%s", domainOfBucket, url.PathEscape(fileKey))
+	} else {
+		fileUrl = fmt.Sprintf("http://%s/%s", domainOfBucket, url.PathEscape(fileKey))
+	}
 	return
 }
 
 // 返回私有空间的下载链接， 也可以用于公有空间的下载
-func (m *BucketManager) MakePrivateDownloadLink(domainOfBucket, fileKey string) (fileUrl string) {
-
-	publicUrl := fmt.Sprintf("http://%s/%s", domainOfBucket, url.PathEscape(fileKey))
+func (m *BucketManager) MakePrivateDownloadLink(domainOfBucket, fileKey string, useHttps bool) (fileUrl string) {
+	var publicUrl string
+	if useHttps {
+		publicUrl = fmt.Sprintf("https://%s/%s", domainOfBucket, url.PathEscape(fileKey))
+	} else {
+		publicUrl = fmt.Sprintf("http://%s/%s", domainOfBucket, url.PathEscape(fileKey))
+	}
 	deadline := time.Now().Add(time.Hour * 24 * 30).Unix()
 	privateUrl, _ := m.PrivateUrl(publicUrl, deadline)
 	fileUrl = privateUrl

--- a/iqshell/qdownload.go
+++ b/iqshell/qdownload.go
@@ -43,6 +43,7 @@ type DownloadConfig struct {
 	Prefix       string `json:"prefix,omitempty"`
 	Suffixes     string `json:"suffixes,omitempty"`
 	IoHost       string `json:"io_host,omitempty"`
+	Public       bool   `json:"public,omitempty"`
 	//down from cdn
 	Referer   string `json:"referer,omitempty"`
 	CdnDomain string `json:"cdn_domain,omitempty"`
@@ -345,7 +346,12 @@ func QiniuDownload(threadCount int, downConfig *DownloadConfig) {
 				continue
 			}
 
-			fileUrl := bm.MakePrivateDownloadLink(downloadDomain, fileKey)
+			var fileUrl string
+			if downConfig.Public {
+				fileUrl = bm.MakePublicDownloadLink(downloadDomain, fileKey)
+			} else {
+				fileUrl = bm.MakePrivateDownloadLink(downloadDomain, fileKey)
+			}
 
 			//progress
 			if totalFileCount != 0 {

--- a/iqshell/qdownload.go
+++ b/iqshell/qdownload.go
@@ -47,7 +47,7 @@ type DownloadConfig struct {
 	//down from cdn
 	Referer   string `json:"referer,omitempty"`
 	CdnDomain string `json:"cdn_domain,omitempty"`
-	UseHttps  bool   `json:"useHttps,omitempty"`
+	UseHttps  bool   `json:"use_https,omitempty"`
 	//log settings
 	LogLevel  string `json:"log_level,omitempty"`
 	LogFile   string `json:"log_file,omitempty"`

--- a/iqshell/qdownload.go
+++ b/iqshell/qdownload.go
@@ -47,6 +47,7 @@ type DownloadConfig struct {
 	//down from cdn
 	Referer   string `json:"referer,omitempty"`
 	CdnDomain string `json:"cdn_domain,omitempty"`
+	UseHttps  bool   `json:"useHttps,omitempty"`
 	//log settings
 	LogLevel  string `json:"log_level,omitempty"`
 	LogFile   string `json:"log_file,omitempty"`
@@ -94,7 +95,6 @@ func (d *DownloadConfig) DownloadDomain() (domain string) {
 	}
 	domain = strings.TrimPrefix(domain, "http://")
 	domain = strings.TrimPrefix(domain, "https://")
-
 	return
 }
 
@@ -348,9 +348,9 @@ func QiniuDownload(threadCount int, downConfig *DownloadConfig) {
 
 			var fileUrl string
 			if downConfig.Public {
-				fileUrl = bm.MakePublicDownloadLink(downloadDomain, fileKey)
+				fileUrl = bm.MakePublicDownloadLink(downloadDomain, fileKey, downConfig.UseHttps)
 			} else {
-				fileUrl = bm.MakePrivateDownloadLink(downloadDomain, fileKey)
+				fileUrl = bm.MakePrivateDownloadLink(downloadDomain, fileKey, downConfig.UseHttps)
 			}
 
 			//progress


### PR DESCRIPTION
#### 变更背景描述

有用户使用我们的qshell工具的qdownload命令下载公开空间文件时， qshell工具也会自动 携带 e 和 token 发起下载请求。导致产生较大的回源流量。需要解决

#### jira issue链接

https://jira.qiniu.io/browse/KODO-10860

#### 主要变更点
- [ ] fix bug
- [x] new feature
- [ ] 不兼容变更 


#### Checklist
- [x] 已自测
- [x] 已更新Readme

