### PR TITLE
qiniu api v7.6.0; add debug info for http.DefaultClient

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -194,13 +194,17 @@ func (t MyTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 func initHttpDefaultClient() {
-	t0 := http.DefaultClient.Transport
-	if t0 == nil {
-		t0 = http.DefaultTransport
-	}
+	t0 := http.DefaultTransport
 	if t0 != nil {
-		http.DefaultClient.Transport = MyTransport{
+		http.DefaultTransport = MyTransport{
 			Transport: t0,
+		}
+	}
+
+	t1 := http.DefaultClient.Transport
+	if t1 != nil {
+		http.DefaultClient.Transport = MyTransport{
+			Transport: t1,
 		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.3.2 // indirect
 	github.com/pelletier/go-toml v1.8.0 // indirect
-	github.com/qiniu/api.v7/v7 v7.5.0
+	github.com/qiniu/api.v7/v7 v7.6.0
 	github.com/satori/go.uuid v1.2.0 // indirect
 	github.com/spf13/afero v1.3.1 // indirect
 	github.com/spf13/cast v1.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -237,8 +237,8 @@ github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7z
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/qiniu/api.v7/v7 v7.5.0 h1:DY6NrIp6FZ1GP4Roc9hRnO2m+OLzASYNnvz5Mbgw1rk=
-github.com/qiniu/api.v7/v7 v7.5.0/go.mod h1:VE5oC5rkE1xul0u1S2N0b2Uxq9/6hZzhyqjgK25XDcM=
+github.com/qiniu/api.v7/v7 v7.6.0 h1:396UGG+AWLh80pIhpPNCgEzb04t4S8CGKxqvLkiQeZI=
+github.com/qiniu/api.v7/v7 v7.6.0/go.mod h1:zg3DaqU8mVnoQSQmtC/Mr2wXTJIE7fvcup+7sMt58Q0=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=


### PR DESCRIPTION
#### 变更背景描述
升级到 qiniu api v7.6.0 ;
qiniu/api.v7   kodo 相关 http 使用了 自定义的 Client 支持打印 http 请求头、请求体；
qiniu/api.v7   cdn 等 api ，使用了  http.DefaultClient ，也添加打印  http 请求头、请求体 能力

qshell -d     打印请求头、响应头
qshell -D     打印请求头、请求体、响应头、响应体

#### jira issue链接
https://jira.qiniu.io/browse/TS-1030

#### 主要变更点
- []fix bug
- [v]new feature
- []不兼容变更 


#### Checklist
- [v] 已自测
- [] 已更新Readme

