### PR TITLE
uc scheme 默认使用 http

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -149,7 +149,7 @@ func initConfig() {
 	iqshell.SetDefaultAccPath(filepath.Join(rootPath, "account.json"))
 	iqshell.SetDefaultRsHost(storage.DefaultRsHost)
 	iqshell.SetDefaultRsfHost(storage.DefaultRsfHost)
-	iqshell.SetDefaultUcHost("https://uc.qbox.me")
+	iqshell.SetDefaultUcHost("http://uc.qbox.me")
 
 	if rErr := viper.ReadInConfig(); rErr != nil {
 		if _, ok := rErr.(viper.ConfigFileNotFoundError); !ok {

--- a/iqshell/config.go
+++ b/iqshell/config.go
@@ -247,7 +247,7 @@ func UcHost() string {
 	}
 
 	if !strings.Contains(host, "://") {
-		host = Endpoint(true, host)
+		host = Endpoint(false, host)
 	}
 	return host
 }


### PR DESCRIPTION
#### 变更背景描述
uc scheme 默认使用 http
有些私有云只允许 http 协议，为了方便配置并且和其他 host 统一，默认 uc scheme 默认调整成 http

#### jira issue链接
https://jira.qiniu.io/projects/KODO/issues/KODO-13202

#### 主要变更点
- [ ] fix bug
- [ ] new feature
- [ ] 不兼容变更 


#### Checklist
- [ ] 已自测
- [ ] 已更新Readme

