### PR TITLE
revert: remove direct release 2.19.2 prep commit

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,6 +45,8 @@ jobs:
             goos: windows
           - goarch: amd64
             goos: windows
+          - goarch: arm
+            goos: windows
           - goarch: arm64
             goos: windows
     steps:
@@ -66,7 +68,7 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: ${{ matrix.goos }}
         goarch: ${{ matrix.goarch }}
-        goversion: "https://go.dev/dl/go1.24.13.linux-amd64.tar.gz"
+        goversion: "https://go.dev/dl/go1.23.2.linux-amd64.tar.gz"
         ldflags: -X "github.com/qiniu/qshell/v2/iqshell/common/version.version=${{ env.APP_VERSION }}" -extldflags "-static"
         project_path: "./main"
         retry: '100'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,3 @@
-# 2.19.2
-## 更新
-1. 升级 `github.com/qiniu/go-sdk/v7` 到 `v7.26.8`，沙箱注入规则与最新 Injection APIs 对齐
-2. `sandbox create` 支持通过 `--injection-rule` 引用已存在的注入规则，也支持通过 `--inline-injection` 直接传入内联注入配置
-
-## 修复
-1. 修复 Windows 平台发布构建中 `syscall.SIGWINCH` 导致的编译失败，完善跨平台终端 resize 处理
-
-## 文档
-1. 补充 `sandbox create` 注入相关文档与示例脚本
-
 # 2.19.1
 ## 优化
 1. 优化批量下载


### PR DESCRIPTION
本 PR 用于回退直接推送到 `master` 的发版准备提交 `3e198def`（`chore(release): prepare 2.19.2`），恢复“所有变更通过 PR 合并”的仓库流程。

背景：
- 该提交直接修改了 `CHANGELOG.md` 和 `.github/workflows/release.yaml`
- 按仓库要求，这类变更也应通过 PR 合入，而不是直接推送到 `upstream/master`
- 与之关联的 `Release 2.19.2`、tag 和 workflow run 已经撤销/取消

回退后，我会基于已准备好的分支重新提交同样的改动，并按正常 PR 流程合并。
