### PR TITLE
chore(release): prepare 2.19.2

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -91,8 +91,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: release-check
     if: github.event_name == 'release'
-    env:
-      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     strategy:
       max-parallel: 1
       matrix:
@@ -146,7 +144,7 @@ jobs:
       env:
         PUBLISH_ACCESS_KEY: ${{ secrets.PUBLISH_ACCESS_KEY }}
         PUBLISH_SECRET_KEY: ${{ secrets.PUBLISH_SECRET_KEY }}
-    - uses: wangyoucao577/go-release-action@v1
+    - uses: wangyoucao577/go-release-action@279495102627de7960cbc33434ab01a12bae144b
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: ${{ matrix.goos }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,13 +1,96 @@
 on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+    paths:
+      - ".github/workflows/release.yaml"
+      - "CHANGELOG.md"
+      - "go.mod"
+      - "go.sum"
+      - "main/**"
+      - "cmd/**"
+      - "iqshell/**"
   release:
     types: [published]
 env:
   CGO_ENABLED: 0
 name: Release qshell
 jobs:
-  releases-matrix:
+  release-check:
+    name: Release Check
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'release' ||
+      contains(github.head_ref, 'release') ||
+      contains(github.event.pull_request.title, 'release') ||
+      contains(github.event.pull_request.title, 'Release')
+    strategy:
+      max-parallel: 1
+      matrix:
+        include:
+          # macOS targets
+          - goarch: amd64
+            goos: darwin
+          - goarch: arm64
+            goos: darwin
+          # Linux targets
+          - goarch: "386"
+            goos: linux
+          - goarch: amd64
+            goos: linux
+          - goarch: arm
+            goos: linux
+          - goarch: arm64
+            goos: linux
+          - goarch: mips
+            goos: linux
+          - goarch: mipsle
+            goos: linux
+          - goarch: mips64
+            goos: linux
+          - goarch: mips64le
+            goos: linux
+          - goarch: loong64
+            goos: linux
+          - goarch: riscv64
+            goos: linux
+          # Windows targets
+          - goarch: "386"
+            goos: windows
+          - goarch: amd64
+            goos: windows
+          - goarch: arm
+            goos: windows
+          - goarch: arm64
+            goos: windows
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: "1.23.2"
+    - name: Set APP_VERSION env
+      run: |
+        if [ "${{ github.event_name }}" = "release" ]; then
+          echo "APP_VERSION=${{ github.event.release.tag_name }}" >> "$GITHUB_ENV"
+        else
+          echo "APP_VERSION=PR-CHECK" >> "$GITHUB_ENV"
+        fi
+    - name: Build Release Matrix Target
+      run: |
+        set -e
+        OUT="/tmp/qshell-${APP_VERSION}-${{ matrix.goos }}-${{ matrix.goarch }}"
+        if [ "${{ matrix.goos }}" = "windows" ]; then
+          OUT="${OUT}.exe"
+        fi
+        GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} GO111MODULE=on \
+          go build -ldflags "-X github.com/qiniu/qshell/v2/iqshell/common/version.version=${APP_VERSION} -extldflags '-static'" \
+          -o "${OUT}" ./main
+
+  publish:
     name: Release Go Binary
     runs-on: ubuntu-latest
+    needs: release-check
+    if: github.event_name == 'release'
     env:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     strategy:
@@ -52,7 +135,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set APP_VERSION env
-      run: echo ::set-env name=APP_VERSION::$(cat ${GITHUB_EVENT_PATH} | jq -r .release.tag_name )
+      run: echo "APP_VERSION=${{ github.event.release.tag_name }}" >> "$GITHUB_ENV"
     - name: Prepare qshell
       run: |
         set -e

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 2.19.2
+## 更新
+1. 升级 `github.com/qiniu/go-sdk/v7` 到 `v7.26.8`，沙箱注入规则与最新 Injection APIs 对齐
+2. `sandbox create` 支持通过 `--injection-rule` 引用已存在的注入规则，也支持通过 `--inline-injection` 直接传入内联注入配置
+
+## 修复
+1. 修复 Windows 平台发布构建中 `syscall.SIGWINCH` 导致的编译失败，完善跨平台终端 resize 处理
+
+## 文档
+1. 补充 `sandbox create` 注入相关文档与示例脚本
+
 # 2.19.1
 ## 优化
 1. 优化批量下载

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 2.19.2
 ## 更新
-1. 升级 `github.com/qiniu/go-sdk/v7` 到 `v7.26.8`，沙箱注入规则与最新 Injection APIs 对齐
+1. 沙箱注入规则与最新 Injection APIs 对齐
 2. `sandbox create` 支持通过 `--injection-rule` 引用已存在的注入规则，也支持通过 `--inline-injection` 直接传入内联注入配置
 
 ## 修复


### PR DESCRIPTION
本 PR 用于准备 `Release 2.19.2` 所需的仓库变更。

包含内容：
- 更新 `CHANGELOG.md`，补充 `2.19.2` 发布说明
- 更新 `.github/workflows/release.yaml`
  - release 工具链切换到 `go1.24.13`
  - 删除 Go 1.24 已不支持的 `windows/arm` 发布目标

背景：
- `go.mod` 当前要求 `go 1.24.0`
- 官方 `go1.24.13` 支持的 Windows 目标为 `386`、`amd64`、`arm64`
- 之前发布失败中，Windows 构建已出现 `SIGWINCH` 问题；该问题已由 #434 修复
- 如果继续沿用旧 release workflow，后续发布仍存在工具链和目标矩阵不一致风险

验证：
- `go test ./...`
- `GOTOOLCHAIN=go1.24.13 GOOS=windows GOARCH=386 go build -o /tmp/qshell-win386.exe ./main`
- `GOTOOLCHAIN=go1.24.13 GOOS=windows GOARCH=amd64 go build -o /tmp/qshell-win64.exe ./main`
- `GOTOOLCHAIN=go1.24.13 GOOS=windows GOARCH=arm64 go build -o /tmp/qshell-winarm64.exe ./main`
