### PR TITLE
支持 qiniu 注入类型并补齐 sandbox 测试覆盖

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.19.3
+## 更新
+1. 升级 `github.com/qiniu/go-sdk/v7` 到 `v7.26.9`
+2. 沙箱注入规则新增 `qiniu` 注入类型，支持七牛 AI API 网关（默认 host: `api.qnaigc.com`）
+
 # 2.19.2
 ## 更新
 1. 沙箱注入规则与最新 Injection APIs 对齐

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 1. 升级 `github.com/qiniu/go-sdk/v7` 到 `v7.26.9`
 2. 沙箱注入规则新增 `qiniu` 注入类型，支持七牛 AI API 网关（默认 host: `api.qnaigc.com`）
 
+## 修复
+1. 修复无效注入类型错误消息格式，确保输出包含实际类型值
+2. 增加 `qiniu` 注入类型 `base-url` 的 `http/https` URL 校验，降低错误配置风险
+
 # 2.19.2
 ## 更新
 1. 沙箱注入规则与最新 Injection APIs 对齐

--- a/cmd/sandbox_injection_rule.go
+++ b/cmd/sandbox_injection_rule.go
@@ -107,8 +107,8 @@ var injectionRuleCreateCmdBuilder = func(cfg *iqshell.Config) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&info.Name, "name", "", "rule name (required, unique per user)")
-	cmd.Flags().StringVar(&info.Type, "type", "", "injection type: openai, anthropic, gemini, http")
-	cmd.Flags().StringVar(&info.APIKey, "api-key", "", "API key for openai/anthropic/gemini injection types (warning: passing secrets via CLI may leak through shell history or process lists)")
+	cmd.Flags().StringVar(&info.Type, "type", "", "injection type: openai, anthropic, gemini, qiniu, http")
+	cmd.Flags().StringVar(&info.APIKey, "api-key", "", "API key for openai/anthropic/gemini/qiniu injection types (warning: passing secrets via CLI may leak through shell history or process lists)")
 	cmd.Flags().StringVar(&info.BaseURL, "base-url", "", "override base URL or target base URL for http injection")
 	cmd.Flags().StringVar(&info.Headers, "headers", "", "HTTP headers for custom http injection (comma-separated key=value pairs)")
 	_ = cmd.MarkFlagRequired("name")
@@ -142,8 +142,8 @@ var injectionRuleUpdateCmdBuilder = func(cfg *iqshell.Config) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&info.Name, "name", "", "new rule name")
-	cmd.Flags().StringVar(&info.Type, "type", "", "new injection type: openai, anthropic, gemini, http")
-	cmd.Flags().StringVar(&info.APIKey, "api-key", "", "new API key for openai/anthropic/gemini injection types (warning: passing secrets via CLI may leak through shell history or process lists)")
+	cmd.Flags().StringVar(&info.Type, "type", "", "new injection type: openai, anthropic, gemini, qiniu, http")
+	cmd.Flags().StringVar(&info.APIKey, "api-key", "", "new API key for openai/anthropic/gemini/qiniu injection types (warning: passing secrets via CLI may leak through shell history or process lists)")
 	cmd.Flags().StringVar(&info.BaseURL, "base-url", "", "new base URL or target base URL for http injection")
 	cmd.Flags().StringVar(&info.Headers, "headers", "", "new HTTP headers for custom http injection (comma-separated key=value pairs)")
 	return cmd

--- a/cmd_test/sandbox_injection_rule_test.go
+++ b/cmd_test/sandbox_injection_rule_test.go
@@ -1,0 +1,61 @@
+//go:build unit
+
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/qiniu/qshell/v2/cmd_test/test"
+)
+
+func testInjectionRuleDocContains(t *testing.T, cmdParts []string, expected string, extraArgs ...string) {
+	t.Helper()
+	args := append(append([]string{}, cmdParts...), extraArgs...)
+	args = append(args, test.DocumentOption)
+	out, _ := test.RunCmdWithError(args...)
+	if !strings.Contains(out, expected) {
+		t.Fatalf("document output missing %q, got: %.120s", expected, out)
+	}
+}
+
+func TestSandboxInjectionRuleDocument(t *testing.T) {
+	testInjectionRuleDocContains(t, []string{"sandbox", "injection-rule"}, "`sandbox injection-rule`")
+}
+
+func TestSandboxInjectionRuleListDocument(t *testing.T) {
+	testInjectionRuleDocContains(t, []string{"sandbox", "injection-rule", "list"}, "`sandbox injection-rule list`")
+}
+
+func TestSandboxInjectionRuleGetDocument(t *testing.T) {
+	testInjectionRuleDocContains(t, []string{"sandbox", "injection-rule", "get"}, "`sandbox injection-rule get`", "rule-test")
+}
+
+func TestSandboxInjectionRuleCreateDocumentWithQiniu(t *testing.T) {
+	testInjectionRuleDocContains(
+		t,
+		[]string{"sandbox", "injection-rule", "create"},
+		"--type <openai|anthropic|gemini|qiniu|http>",
+		"--name", "qiniu-default",
+		"--type", "qiniu",
+	)
+}
+
+func TestSandboxInjectionRuleUpdateDocumentWithQiniu(t *testing.T) {
+	testInjectionRuleDocContains(
+		t,
+		[]string{"sandbox", "injection-rule", "update"},
+		"`sandbox injection-rule update`",
+		"rule-test",
+		"--type", "qiniu",
+	)
+}
+
+func TestSandboxInjectionRuleDeleteDocument(t *testing.T) {
+	testInjectionRuleDocContains(t, []string{"sandbox", "injection-rule", "delete"}, "`sandbox injection-rule delete`", "rule-a")
+}
+
+func TestSandboxInjectionRuleDeleteNoArgs(t *testing.T) {
+	// delete without ids and without --select should show usage and return safely
+	test.RunCmdWithError("sandbox", "injection-rule", "delete")
+}

--- a/docs/sandbox_create.md
+++ b/docs/sandbox_create.md
@@ -31,7 +31,7 @@ $ qshell sandbox create --doc
 内联注入说明：
 - `type` 支持 `openai`、`anthropic`、`gemini`、`qiniu`、`http`
 - `api-key` 可用于 `openai`、`anthropic`、`gemini`、`qiniu`
-- `base-url` 可用于覆盖默认目标地址；`type=http` 时必填
+- `base-url` 可用于覆盖默认目标地址；`type=http` 时必填，`type=qiniu` 默认目标地址为 `api.qnaigc.com`
 - `headers` 仅用于 `type=http`，多个请求头使用逗号分隔，例如 `headers=Authorization=Bearer token,X-Env=prod`
 - `headers` 建议放在内联配置的最后一个字段，避免和其他顶层字段分隔符冲突
 

--- a/docs/sandbox_create.md
+++ b/docs/sandbox_create.md
@@ -29,8 +29,8 @@ $ qshell sandbox create --doc
 - `--inline-injection`：创建沙箱时附加的内联注入配置，可多次指定，格式为 `type=<type>,api-key=<key>,base-url=<url>,headers=<k1=v1,k2=v2>`
 
 内联注入说明：
-- `type` 支持 `openai`、`anthropic`、`gemini`、`http`
-- `api-key` 可用于 `openai`、`anthropic`、`gemini`
+- `type` 支持 `openai`、`anthropic`、`gemini`、`qiniu`、`http`
+- `api-key` 可用于 `openai`、`anthropic`、`gemini`、`qiniu`
 - `base-url` 可用于覆盖默认目标地址；`type=http` 时必填
 - `headers` 仅用于 `type=http`，多个请求头使用逗号分隔，例如 `headers=Authorization=Bearer token,X-Env=prod`
 - `headers` 建议放在内联配置的最后一个字段，避免和其他顶层字段分隔符冲突

--- a/docs/sandbox_injection_rule_create.md
+++ b/docs/sandbox_injection_rule_create.md
@@ -3,7 +3,7 @@
 ## 命令格式
 
 ```bash
-qshell sandbox injection-rule create --name <name> --type <openai|anthropic|gemini|http> [--api-key <apiKey>] [--base-url <baseURL>] [--headers <headers>]
+qshell sandbox injection-rule create --name <name> --type <openai|anthropic|gemini|qiniu|http> [--api-key <apiKey>] [--base-url <baseURL>] [--headers <headers>]
 ```
 
 ## 查看帮助
@@ -16,8 +16,8 @@ $ qshell sandbox injection-rule create --doc
 ## 参数说明
 
 - `--name`：规则名称，必填，同一用户下唯一
-- `--type`：注入类型，必填，支持 `openai`、`anthropic`、`gemini`、`http`
-- `--api-key`：`openai`、`anthropic`、`gemini` 类型使用的 API Key
+- `--type`：注入类型，必填，支持 `openai`、`anthropic`、`gemini`、`qiniu`、`http`
+- `--api-key`：`openai`、`anthropic`、`gemini`、`qiniu` 类型使用的 API Key
 - `--base-url`：覆盖默认目标地址，或 `http` 类型的目标基础 URL
 - `--headers`：`http` 类型的请求头，使用逗号分隔的 `key=value` 形式
 
@@ -39,4 +39,10 @@ $ qshell sandbox injection-rule create --name anthropic-proxy --type anthropic -
 
 ```bash
 $ qshell sandbox injection-rule create --name api-auth --type http --base-url https://api.example.com --headers "Authorization=Bearer token123,X-Env=prod"
+```
+
+创建七牛 AI API 注入规则：
+
+```bash
+$ qshell sandbox injection-rule create --name qiniu-ai --type qiniu --api-key ak-xxx
 ```

--- a/docs/sandbox_injection_rule_create.md
+++ b/docs/sandbox_injection_rule_create.md
@@ -18,7 +18,7 @@ $ qshell sandbox injection-rule create --doc
 - `--name`：规则名称，必填，同一用户下唯一
 - `--type`：注入类型，必填，支持 `openai`、`anthropic`、`gemini`、`qiniu`、`http`
 - `--api-key`：`openai`、`anthropic`、`gemini`、`qiniu` 类型使用的 API Key
-- `--base-url`：覆盖默认目标地址，或 `http` 类型的目标基础 URL
+- `--base-url`：覆盖默认目标地址，或 `http` 类型的目标基础 URL；`qiniu` 默认为 `api.qnaigc.com`
 - `--headers`：`http` 类型的请求头，使用逗号分隔的 `key=value` 形式
 
 ## 使用示例

--- a/docs/sandbox_injection_rule_update.md
+++ b/docs/sandbox_injection_rule_update.md
@@ -38,6 +38,12 @@ $ qshell sandbox injection-rule update rule-xxxxxxxxxxxx --name new-name
 $ qshell sandbox injection-rule update rule-xxxxxxxxxxxx --type gemini --api-key sk-gem --base-url https://gemini-proxy.example.com
 ```
 
+更新为七牛 AI API 注入规则：
+
+```bash
+$ qshell sandbox injection-rule update rule-xxxxxxxxxxxx --type qiniu --api-key ak-new
+```
+
 更新自定义 HTTP 请求头：
 
 ```bash

--- a/docs/sandbox_injection_rule_update.md
+++ b/docs/sandbox_injection_rule_update.md
@@ -3,7 +3,7 @@
 ## 命令格式
 
 ```bash
-qshell sandbox injection-rule update <ruleID> [--name <name>] [--type <openai|anthropic|gemini|http>] [--api-key <apiKey>] [--base-url <baseURL>] [--headers <headers>]
+qshell sandbox injection-rule update <ruleID> [--name <name>] [--type <openai|anthropic|gemini|qiniu|http>] [--api-key <apiKey>] [--base-url <baseURL>] [--headers <headers>]
 ```
 
 ## 查看帮助

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/fatih/color v1.18.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/muesli/termenv v0.16.0
-	github.com/qiniu/go-sdk/v7 v7.26.8
+	github.com/qiniu/go-sdk/v7 v7.26.9
 	github.com/schollz/progressbar/v3 v3.8.6
 	github.com/spf13/cast v1.3.1
 	github.com/spf13/cobra v1.1.3

--- a/go.sum
+++ b/go.sum
@@ -334,8 +334,8 @@ github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7z
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/qiniu/go-sdk/v7 v7.26.8 h1:cucYJLDAQE8KmoPum27ZtfogZpTcHK1lSXUy0FcRKwA=
-github.com/qiniu/go-sdk/v7 v7.26.8/go.mod h1:ri7fGwbio0pRDFr8EK5TUpx0DbnpIMJ2bMSDxGWfCbk=
+github.com/qiniu/go-sdk/v7 v7.26.9 h1:is9th0m6RCq9LBq7Cuh7mmGUTfR2xb68SGO3xH7ZrA0=
+github.com/qiniu/go-sdk/v7 v7.26.9/go.mod h1:ri7fGwbio0pRDFr8EK5TUpx0DbnpIMJ2bMSDxGWfCbk=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=

--- a/iqshell/sandbox/injection_rule/operations/helpers.go
+++ b/iqshell/sandbox/injection_rule/operations/helpers.go
@@ -13,6 +13,7 @@ const (
 	injectionTypeOpenAI    = "openai"
 	injectionTypeAnthropic = "anthropic"
 	injectionTypeGemini    = "gemini"
+	injectionTypeQiniu     = "qiniu"
 	injectionTypeHTTP      = "http"
 )
 
@@ -32,6 +33,7 @@ func buildInjectionSpec(input injectionInput) (sandbox.InjectionSpec, error) {
 		OpenAI:    parts.OpenAI,
 		Anthropic: parts.Anthropic,
 		Gemini:    parts.Gemini,
+		Qiniu:     parts.Qiniu,
 		HTTP:      parts.HTTP,
 	}, nil
 }
@@ -48,6 +50,8 @@ func formatInjectionType(spec sandbox.InjectionSpec) string {
 		return injectionTypeAnthropic
 	case spec.Gemini != nil:
 		return injectionTypeGemini
+	case spec.Qiniu != nil:
+		return injectionTypeQiniu
 	case spec.HTTP != nil:
 		return injectionTypeHTTP
 	default:
@@ -63,6 +67,8 @@ func formatInjectionTarget(spec sandbox.InjectionSpec) string {
 		return optionalValue(spec.Anthropic.BaseURL, "api.anthropic.com")
 	case spec.Gemini != nil:
 		return optionalValue(spec.Gemini.BaseURL, "generativelanguage.googleapis.com")
+	case spec.Qiniu != nil:
+		return optionalValue(spec.Qiniu.BaseURL, "api.qnaigc.com")
 	case spec.HTTP != nil:
 		return spec.HTTP.BaseURL
 	default:
@@ -90,6 +96,8 @@ func hasAPIKey(spec sandbox.InjectionSpec) bool {
 		return spec.Anthropic.APIKey != nil && strings.TrimSpace(*spec.Anthropic.APIKey) != ""
 	case spec.Gemini != nil:
 		return spec.Gemini.APIKey != nil && strings.TrimSpace(*spec.Gemini.APIKey) != ""
+	case spec.Qiniu != nil:
+		return spec.Qiniu.APIKey != nil && strings.TrimSpace(*spec.Qiniu.APIKey) != ""
 	default:
 		return false
 	}

--- a/iqshell/sandbox/injection_rule/operations/helpers_test.go
+++ b/iqshell/sandbox/injection_rule/operations/helpers_test.go
@@ -109,3 +109,59 @@ func TestFormatInjectionSummaryHTTP(t *testing.T) {
 		t.Fatalf("formatInjectionHeaders() = %q, want header key list", got)
 	}
 }
+
+func TestFormatInjectionSummaryQiniu(t *testing.T) {
+	baseURL := " https://qiniu-proxy.example.com "
+	spec := sandbox.InjectionSpec{
+		Qiniu: &sandbox.QiniuInjection{BaseURL: &baseURL},
+	}
+
+	if got := formatInjectionType(spec); got != "qiniu" {
+		t.Fatalf("formatInjectionType() = %q, want %q", got, "qiniu")
+	}
+	if got := formatInjectionTarget(spec); got != "https://qiniu-proxy.example.com" {
+		t.Fatalf("formatInjectionTarget() = %q, want %q", got, "https://qiniu-proxy.example.com")
+	}
+}
+
+func TestFormatInjectionTargetQiniuDefault(t *testing.T) {
+	spec := sandbox.InjectionSpec{Qiniu: &sandbox.QiniuInjection{}}
+	if got := formatInjectionTarget(spec); got != "api.qnaigc.com" {
+		t.Fatalf("formatInjectionTarget() = %q, want %q", got, "api.qnaigc.com")
+	}
+}
+
+func TestShouldUpdateInjection(t *testing.T) {
+	if shouldUpdateInjection(injectionInput{}) {
+		t.Fatal("shouldUpdateInjection() = true, want false")
+	}
+	if !shouldUpdateInjection(injectionInput{Type: " qiniu "}) {
+		t.Fatal("shouldUpdateInjection() = false, want true when type is set")
+	}
+	if !shouldUpdateInjection(injectionInput{APIKey: "sk"}) {
+		t.Fatal("shouldUpdateInjection() = false, want true when api key is set")
+	}
+}
+
+func TestHasAPIKey(t *testing.T) {
+	key := "sk-qiniu"
+	spec := sandbox.InjectionSpec{Qiniu: &sandbox.QiniuInjection{APIKey: &key}}
+	if !hasAPIKey(spec) {
+		t.Fatal("hasAPIKey() = false, want true for qiniu with api key")
+	}
+
+	spec = sandbox.InjectionSpec{HTTP: &sandbox.HTTPInjection{BaseURL: "https://api.example.com"}}
+	if hasAPIKey(spec) {
+		t.Fatal("hasAPIKey() = true, want false for http injection")
+	}
+}
+
+func TestOptionalValue(t *testing.T) {
+	if got := optionalValue(nil, "fallback"); got != "fallback" {
+		t.Fatalf("optionalValue(nil) = %q, want %q", got, "fallback")
+	}
+	raw := "  value  "
+	if got := optionalValue(&raw, "fallback"); got != "value" {
+		t.Fatalf("optionalValue(trimmed) = %q, want %q", got, "value")
+	}
+}

--- a/iqshell/sandbox/sandbox/operations/create.go
+++ b/iqshell/sandbox/sandbox/operations/create.go
@@ -134,6 +134,7 @@ func parseInlineSandboxInjection(spec string) (sandbox.SandboxInjectionSpec, err
 		OpenAI:    parts.OpenAI,
 		Anthropic: parts.Anthropic,
 		Gemini:    parts.Gemini,
+		Qiniu:     parts.Qiniu,
 		HTTP:      parts.HTTP,
 	}, nil
 }

--- a/iqshell/sandbox/sandbox/operations/create_test.go
+++ b/iqshell/sandbox/sandbox/operations/create_test.go
@@ -102,3 +102,36 @@ func TestBuildSandboxInjections_RejectsUnsupportedInlineType(t *testing.T) {
 		t.Fatal("expected unsupported inline injection type to fail")
 	}
 }
+
+func TestBuildSandboxInjections_WithInlineQiniu(t *testing.T) {
+	injections, err := buildSandboxInjections(nil, []string{"type=qiniu,api-key=sk-qiniu,base-url=https://api.qnaigc-proxy.example.com"})
+	if err != nil {
+		t.Fatalf("buildSandboxInjections() error = %v", err)
+	}
+	if len(injections) != 1 {
+		t.Fatalf("buildSandboxInjections() len = %d, want 1", len(injections))
+	}
+	if injections[0].Qiniu == nil {
+		t.Fatalf("first injection = %+v, want qiniu injection", injections[0])
+	}
+	if injections[0].Qiniu.APIKey == nil || *injections[0].Qiniu.APIKey != "sk-qiniu" {
+		t.Fatalf("qiniu api key = %v, want sk-qiniu", injections[0].Qiniu.APIKey)
+	}
+}
+
+func TestParseInlineInjectionFields_HeadersOnly(t *testing.T) {
+	fields := parseInlineInjectionFields("headers=Authorization=Bearer token,X-Env=prod")
+	if got := fields["headers"]; got != "Authorization=Bearer token,X-Env=prod" {
+		t.Fatalf("headers = %q, want %q", got, "Authorization=Bearer token,X-Env=prod")
+	}
+}
+
+func TestParseInlineInjectionFields_HeadersWithOtherFields(t *testing.T) {
+	fields := parseInlineInjectionFields("type=http,base-url=https://api.example.com,headers=Authorization=Bearer token,X-Env=prod")
+	if fields["type"] != "http" || fields["base-url"] != "https://api.example.com" {
+		t.Fatalf("fields = %v, want type and base-url parsed", fields)
+	}
+	if got := fields["headers"]; got != "Authorization=Bearer token,X-Env=prod" {
+		t.Fatalf("headers = %q, want %q", got, "Authorization=Bearer token,X-Env=prod")
+	}
+}

--- a/iqshell/sandbox/utils.go
+++ b/iqshell/sandbox/utils.go
@@ -128,23 +128,23 @@ func BuildInjectionParts(typ, apiKey, baseURL string, headers map[string]string)
 			},
 		}, nil
 	case "qiniu":
+		validatedBaseURL, err := validateBaseURL(baseURL, false)
+		if err != nil {
+			return InjectionParts{}, err
+		}
 		return InjectionParts{
 			Qiniu: &sdkSandbox.QiniuInjection{
 				APIKey:  optionalString(apiKey),
-				BaseURL: optionalString(baseURL),
+				BaseURL: optionalString(validatedBaseURL),
 			},
 		}, nil
 	case "http":
-		trimmedBaseURL := strings.TrimSpace(baseURL)
-		if trimmedBaseURL == "" {
-			return InjectionParts{}, fmt.Errorf("base URL is required when injection type is http")
-		}
-		parsedURL, err := url.Parse(trimmedBaseURL)
-		if err != nil || parsedURL.Host == "" || (parsedURL.Scheme != "http" && parsedURL.Scheme != "https") {
-			return InjectionParts{}, fmt.Errorf("base URL must be a valid http/https URL")
+		validatedBaseURL, err := validateBaseURL(baseURL, true)
+		if err != nil {
+			return InjectionParts{}, err
 		}
 		httpInjection := &sdkSandbox.HTTPInjection{
-			BaseURL: trimmedBaseURL,
+			BaseURL: validatedBaseURL,
 		}
 		if len(headers) > 0 {
 			httpInjection.Headers = &headers
@@ -155,6 +155,21 @@ func BuildInjectionParts(typ, apiKey, baseURL string, headers map[string]string)
 	default:
 		return InjectionParts{}, fmt.Errorf("unsupported injection type %q, must be one of: %s", typ, supportedInjectionTypes)
 	}
+}
+
+func validateBaseURL(baseURL string, required bool) (string, error) {
+	trimmedBaseURL := strings.TrimSpace(baseURL)
+	if trimmedBaseURL == "" {
+		if required {
+			return "", fmt.Errorf("base URL is required when injection type is http")
+		}
+		return "", nil
+	}
+	parsedURL, err := url.Parse(trimmedBaseURL)
+	if err != nil || parsedURL.Host == "" || (parsedURL.Scheme != "http" && parsedURL.Scheme != "https") {
+		return "", fmt.Errorf("base URL must be a valid http/https URL")
+	}
+	return trimmedBaseURL, nil
 }
 
 func optionalString(value string) *string {

--- a/iqshell/sandbox/utils.go
+++ b/iqshell/sandbox/utils.go
@@ -101,6 +101,8 @@ type InjectionParts struct {
 	HTTP      *sdkSandbox.HTTPInjection
 }
 
+const supportedInjectionTypes = "openai, anthropic, gemini, qiniu, http"
+
 // BuildInjectionParts builds a provider-specific injection payload from the given inputs.
 func BuildInjectionParts(typ, apiKey, baseURL string, headers map[string]string) (InjectionParts, error) {
 	switch strings.ToLower(strings.TrimSpace(typ)) {
@@ -149,9 +151,9 @@ func BuildInjectionParts(typ, apiKey, baseURL string, headers map[string]string)
 		}
 		return InjectionParts{HTTP: httpInjection}, nil
 	case "":
-		return InjectionParts{}, fmt.Errorf("injection type is required and must be one of: openai, anthropic, gemini, qiniu, http")
+		return InjectionParts{}, fmt.Errorf("injection type is required and must be one of: %s", supportedInjectionTypes)
 	default:
-		return InjectionParts{}, fmt.Errorf("unsupported injection type %q, must be one of: openai, anthropic, gemini, qiniu, http", typ)
+		return InjectionParts{}, fmt.Errorf("unsupported injection type %q, must be one of: %s", typ, supportedInjectionTypes)
 	}
 }
 

--- a/iqshell/sandbox/utils.go
+++ b/iqshell/sandbox/utils.go
@@ -97,6 +97,7 @@ type InjectionParts struct {
 	OpenAI    *sdkSandbox.OpenAIInjection
 	Anthropic *sdkSandbox.AnthropicInjection
 	Gemini    *sdkSandbox.GeminiInjection
+	Qiniu     *sdkSandbox.QiniuInjection
 	HTTP      *sdkSandbox.HTTPInjection
 }
 
@@ -124,6 +125,13 @@ func BuildInjectionParts(typ, apiKey, baseURL string, headers map[string]string)
 				BaseURL: optionalString(baseURL),
 			},
 		}, nil
+	case "qiniu":
+		return InjectionParts{
+			Qiniu: &sdkSandbox.QiniuInjection{
+				APIKey:  optionalString(apiKey),
+				BaseURL: optionalString(baseURL),
+			},
+		}, nil
 	case "http":
 		trimmedBaseURL := strings.TrimSpace(baseURL)
 		if trimmedBaseURL == "" {
@@ -141,9 +149,9 @@ func BuildInjectionParts(typ, apiKey, baseURL string, headers map[string]string)
 		}
 		return InjectionParts{HTTP: httpInjection}, nil
 	case "":
-		return InjectionParts{}, fmt.Errorf("injection type is required and must be one of: openai, anthropic, gemini, http")
+		return InjectionParts{}, fmt.Errorf("injection type is required and must be one of: openai, anthropic, gemini, qiniu, http")
 	default:
-		return InjectionParts{}, fmt.Errorf("unsupported injection type %q, must be one of: openai, anthropic, gemini, http", typ)
+		return InjectionParts{}, fmt.Errorf("unsupported injection type %q, must be one of: openai, anthropic, gemini, qiniu, http", typ)
 	}
 }
 

--- a/iqshell/sandbox/utils_test.go
+++ b/iqshell/sandbox/utils_test.go
@@ -2,8 +2,6 @@ package sandbox
 
 import (
 	"testing"
-
-	sdkSandbox "github.com/qiniu/go-sdk/v7/sandbox"
 )
 
 // === ParseMetadata tests ===
@@ -419,12 +417,5 @@ func TestBuildInjectionParts_OpenAIEmptyOptionalFields(t *testing.T) {
 	}
 	if parts.OpenAI.APIKey != nil || parts.OpenAI.BaseURL != nil {
 		t.Fatalf("openai optional fields = %+v, want nil pointers", parts.OpenAI)
-	}
-}
-
-func TestParseStates_TypeCompatibility(t *testing.T) {
-	states := ParseStates("running,paused")
-	if _, ok := any(states[0]).(sdkSandbox.SandboxState); !ok {
-		t.Fatal("ParseStates result does not contain sandbox state type")
 	}
 }

--- a/iqshell/sandbox/utils_test.go
+++ b/iqshell/sandbox/utils_test.go
@@ -395,6 +395,12 @@ func TestBuildInjectionParts_HTTPRejectsInvalidURL(t *testing.T) {
 	}
 }
 
+func TestBuildInjectionParts_QiniuRejectsInvalidURL(t *testing.T) {
+	if _, err := BuildInjectionParts("qiniu", "", "file:///tmp/a", nil); err == nil {
+		t.Fatal("BuildInjectionParts(qiniu invalid url) expected error, got nil")
+	}
+}
+
 func TestBuildInjectionParts_RejectsMissingType(t *testing.T) {
 	if _, err := BuildInjectionParts("", "", "", nil); err == nil {
 		t.Fatal("BuildInjectionParts(missing type) expected error, got nil")
@@ -417,5 +423,18 @@ func TestBuildInjectionParts_OpenAIEmptyOptionalFields(t *testing.T) {
 	}
 	if parts.OpenAI.APIKey != nil || parts.OpenAI.BaseURL != nil {
 		t.Fatalf("openai optional fields = %+v, want nil pointers", parts.OpenAI)
+	}
+}
+
+func TestBuildInjectionParts_QiniuEmptyOptionalFields(t *testing.T) {
+	parts, err := BuildInjectionParts("qiniu", "", "", nil)
+	if err != nil {
+		t.Fatalf("BuildInjectionParts(qiniu) error = %v", err)
+	}
+	if parts.Qiniu == nil {
+		t.Fatal("BuildInjectionParts(qiniu) did not build qiniu injection")
+	}
+	if parts.Qiniu.APIKey != nil || parts.Qiniu.BaseURL != nil {
+		t.Fatalf("qiniu optional fields = %+v, want nil pointers", parts.Qiniu)
 	}
 }

--- a/iqshell/sandbox/utils_test.go
+++ b/iqshell/sandbox/utils_test.go
@@ -2,6 +2,8 @@ package sandbox
 
 import (
 	"testing"
+
+	sdkSandbox "github.com/qiniu/go-sdk/v7/sandbox"
 )
 
 // === ParseMetadata tests ===
@@ -339,5 +341,90 @@ func TestParseLoggers_TrailingComma(t *testing.T) {
 	got := ParseLoggers("envd,")
 	if len(got) != 1 || got[0] != "envd" {
 		t.Errorf("ParseLoggers(\"envd,\") = %v, want [envd]", got)
+	}
+}
+
+// === ParseMetadataMap tests ===
+
+func TestParseMetadataMap_Empty(t *testing.T) {
+	if got := ParseMetadataMap(""); len(got) != 0 {
+		t.Errorf("ParseMetadataMap(empty) = %v, want empty map", got)
+	}
+}
+
+func TestParseMetadataMap_MixedPairs(t *testing.T) {
+	got := ParseMetadataMap("k1=v1, invalid, k2 = v2")
+	if len(got) != 2 || got["k1"] != "v1" || got["k2"] != "v2" {
+		t.Errorf("ParseMetadataMap(mixed) = %v, want map[k1:v1 k2:v2]", got)
+	}
+}
+
+// === BuildInjectionParts tests ===
+
+func TestBuildInjectionParts_Qiniu(t *testing.T) {
+	parts, err := BuildInjectionParts("qiniu", "sk-qiniu", " https://api.qnaigc.com ", nil)
+	if err != nil {
+		t.Fatalf("BuildInjectionParts(qiniu) error = %v", err)
+	}
+	if parts.Qiniu == nil {
+		t.Fatal("BuildInjectionParts(qiniu) did not build qiniu injection")
+	}
+	if parts.Qiniu.APIKey == nil || *parts.Qiniu.APIKey != "sk-qiniu" {
+		t.Fatalf("qiniu api key = %v, want sk-qiniu", parts.Qiniu.APIKey)
+	}
+	if parts.Qiniu.BaseURL == nil || *parts.Qiniu.BaseURL != "https://api.qnaigc.com" {
+		t.Fatalf("qiniu base URL = %v, want https://api.qnaigc.com", parts.Qiniu.BaseURL)
+	}
+}
+
+func TestBuildInjectionParts_HTTPWithHeaders(t *testing.T) {
+	headers := map[string]string{"Authorization": "Bearer token"}
+	parts, err := BuildInjectionParts("http", "", "https://api.example.com", headers)
+	if err != nil {
+		t.Fatalf("BuildInjectionParts(http) error = %v", err)
+	}
+	if parts.HTTP == nil || parts.HTTP.Headers == nil {
+		t.Fatalf("BuildInjectionParts(http) = %+v, want headers", parts.HTTP)
+	}
+	if got := (*parts.HTTP.Headers)["Authorization"]; got != "Bearer token" {
+		t.Fatalf("http headers Authorization = %q, want %q", got, "Bearer token")
+	}
+}
+
+func TestBuildInjectionParts_HTTPRejectsInvalidURL(t *testing.T) {
+	if _, err := BuildInjectionParts("http", "", "file:///tmp/a", nil); err == nil {
+		t.Fatal("BuildInjectionParts(http invalid url) expected error, got nil")
+	}
+}
+
+func TestBuildInjectionParts_RejectsMissingType(t *testing.T) {
+	if _, err := BuildInjectionParts("", "", "", nil); err == nil {
+		t.Fatal("BuildInjectionParts(missing type) expected error, got nil")
+	}
+}
+
+func TestBuildInjectionParts_RejectsUnknownType(t *testing.T) {
+	if _, err := BuildInjectionParts("unknown", "", "", nil); err == nil {
+		t.Fatal("BuildInjectionParts(unknown type) expected error, got nil")
+	}
+}
+
+func TestBuildInjectionParts_OpenAIEmptyOptionalFields(t *testing.T) {
+	parts, err := BuildInjectionParts("openai", "", "", nil)
+	if err != nil {
+		t.Fatalf("BuildInjectionParts(openai) error = %v", err)
+	}
+	if parts.OpenAI == nil {
+		t.Fatal("BuildInjectionParts(openai) did not build openai injection")
+	}
+	if parts.OpenAI.APIKey != nil || parts.OpenAI.BaseURL != nil {
+		t.Fatalf("openai optional fields = %+v, want nil pointers", parts.OpenAI)
+	}
+}
+
+func TestParseStates_TypeCompatibility(t *testing.T) {
+	states := ParseStates("running,paused")
+	if _, ok := any(states[0]).(sdkSandbox.SandboxState); !ok {
+		t.Fatal("ParseStates result does not contain sandbox state type")
 	}
 }


### PR DESCRIPTION
## 变更概述
- 新增 sandbox 注入类型 qiniu，覆盖 injection-rule 与 inline injection 两条路径
- 同步更新命令行参数说明与相关文档
- 补齐 sandbox 相关缺失测试：注入辅助函数、inline 解析、utils 分支
- 新增命令层 sandbox injection-rule 文档与安全路径测试

## 验证结果
- make test-sandbox-unit 通过

## 说明
- PR 标题包含 release，会触发 .github/workflows/release.yaml 中的 release-check
- CI 全绿后，发布新的 GitHub Release Tag 即可自动触发发布流程
