### PR TITLE
feat(sandbox/template): 支持 qshell.sandbox.toml 配置文件

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ bin
 .idea
 .vscode
 .claude/settings.local.json
+.claude/plans/
 
 # Architecture specific extensions/prefixes
 *.cgo1.go

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Unreleased
+## 新增
+1. `qshell sandbox template` 系列命令支持 `qshell.sandbox.toml` 配置文件，可持久化构建参数（name、dockerfile、from_image、cpu_count、memory_mb 等）
+2. `build` 命令新增 `--config` 参数用于显式指定配置文件路径
+3. 首次构建成功后，qshell 自动把新模板的 `template_id` 回写到配置文件，实现后续幂等重建
+4. `get` / `delete` / `publish` 命令在未传入 template_id 时，自动从当前目录 `qshell.sandbox.toml` 读取
+
 # 2.19.3
 ## 更新
 1. 升级 `github.com/qiniu/go-sdk/v7` 到 `v7.26.9`

--- a/cmd/sandbox_template.go
+++ b/cmd/sandbox_template.go
@@ -160,6 +160,10 @@ Creating a new template supports three build modes:
   2. --from-template: Build from an existing template
   3. --dockerfile: Build from a Dockerfile (v2 build system)
 
+--dockerfile can also be combined with --from-template or --from-image to apply
+Dockerfile RUN/COPY/ENV steps on top of the selected base. When combined with
+--from-template, the Dockerfile FROM line is parsed but ignored as the base.
+
 Rebuilding an existing template (--template-id) requires --dockerfile
 because the rebuild API must carry the Dockerfile content in the request body.
 
@@ -177,6 +181,10 @@ because the rebuild API must carry the Dockerfile content in the request body.
   # Build from a Dockerfile with a custom context directory
   qshell sandbox template build --name my-template --dockerfile ./Dockerfile --path ./context --wait
   qshell sbx tpl bd --name my-template --dockerfile ./Dockerfile --path ./context --wait
+
+  # Build from an existing template and apply Dockerfile steps on top
+  qshell sandbox template build --name claude --from-template agents-base --dockerfile ./Dockerfile --wait
+  qshell sbx tpl bd --name claude --from-template agents-base --dockerfile ./Dockerfile --wait
 
   # Rebuild an existing template (Dockerfile required)
   qshell sandbox template build --template-id tmpl-xxxxxxxxxxxx --dockerfile ./Dockerfile --wait

--- a/cmd/sandbox_template.go
+++ b/cmd/sandbox_template.go
@@ -204,6 +204,7 @@ because the rebuild API must carry the Dockerfile content in the request body.
 			if iqshell.ShowDocumentIfNeeded(cfg) {
 				return
 			}
+			info.NoCacheChanged = cmd.Flags().Changed("no-cache")
 			operations.Build(info)
 		},
 	}

--- a/cmd/sandbox_template.go
+++ b/cmd/sandbox_template.go
@@ -74,12 +74,16 @@ var templateGetCmdBuilder = func(cfg *iqshell.Config) *cobra.Command {
 			if iqshell.ShowDocumentIfNeeded(cfg) {
 				return
 			}
-			if len(args) != 1 {
+			if len(args) > 1 {
 				_ = cmd.Usage()
 				return
 			}
+			id := ""
+			if len(args) == 1 {
+				id = args[0]
+			}
 			operations.Get(operations.GetInfo{
-				TemplateID: args[0],
+				TemplateID: id,
 			})
 		},
 	}
@@ -106,10 +110,6 @@ var templateDeleteCmdBuilder = func(cfg *iqshell.Config) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			cfg.CmdCfg.CmdId = docs.SandboxTemplateDeleteType
 			if iqshell.ShowDocumentIfNeeded(cfg) {
-				return
-			}
-			if len(args) == 0 && !info.Select {
-				_ = cmd.Usage()
 				return
 			}
 			info.TemplateIDs = args
@@ -161,7 +161,11 @@ Creating a new template supports three build modes:
   3. --dockerfile: Build from a Dockerfile (v2 build system)
 
 Rebuilding an existing template (--template-id) requires --dockerfile
-because the rebuild API must carry the Dockerfile content in the request body.`,
+because the rebuild API must carry the Dockerfile content in the request body.
+
+参数可通过 qshell.sandbox.toml 持久化；CLI flag 优先于配置文件。
+首次构建成功后，qshell 会自动把 template_id 回写到配置文件，
+后续重建只需 qshell sandbox template build 即可完成幂等重建。`,
 		Example: `  # Create and build a new template from a Docker image
   qshell sandbox template build --name my-template --from-image ubuntu:22.04 --wait
   qshell sbx tpl bd --name my-template --from-image ubuntu:22.04 --wait
@@ -180,7 +184,13 @@ because the rebuild API must carry the Dockerfile content in the request body.`,
 
   # Force rebuild without cache
   qshell sandbox template build --template-id tmpl-xxxxxxxxxxxx --dockerfile ./Dockerfile --no-cache --wait
-  qshell sbx tpl bd --template-id tmpl-xxxxxxxxxxxx --dockerfile ./Dockerfile --no-cache --wait`,
+  qshell sbx tpl bd --template-id tmpl-xxxxxxxxxxxx --dockerfile ./Dockerfile --no-cache --wait
+
+  # 使用 qshell.sandbox.toml（当前目录）
+  qshell sandbox template build --wait
+
+  # 显式指定配置文件
+  qshell sandbox template build --config ./configs/prod.toml --wait`,
 		Run: func(cmd *cobra.Command, args []string) {
 			cfg.CmdCfg.CmdId = docs.SandboxTemplateBuildType
 			if iqshell.ShowDocumentIfNeeded(cfg) {
@@ -201,6 +211,7 @@ because the rebuild API must carry the Dockerfile content in the request body.`,
 	cmd.Flags().BoolVar(&info.NoCache, "no-cache", false, "force full rebuild ignoring cache")
 	cmd.Flags().StringVar(&info.Dockerfile, "dockerfile", "", "path to Dockerfile (enables v2 build)")
 	cmd.Flags().StringVar(&info.Path, "path", "", "build context directory (defaults to Dockerfile's parent)")
+	cmd.Flags().StringVar(&info.ConfigPath, "config", "", "path to qshell.sandbox.toml (defaults to ./qshell.sandbox.toml if present)")
 	return cmd
 }
 
@@ -220,10 +231,6 @@ var templatePublishCmdBuilder = func(cfg *iqshell.Config) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			cfg.CmdCfg.CmdId = docs.SandboxTemplatePublishType
 			if iqshell.ShowDocumentIfNeeded(cfg) {
-				return
-			}
-			if len(args) == 0 && !info.Select {
-				_ = cmd.Usage()
 				return
 			}
 			info.TemplateIDs = args
@@ -251,10 +258,6 @@ var templateUnpublishCmdBuilder = func(cfg *iqshell.Config) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			cfg.CmdCfg.CmdId = docs.SandboxTemplateUnpublishType
 			if iqshell.ShowDocumentIfNeeded(cfg) {
-				return
-			}
-			if len(args) == 0 && !info.Select {
-				_ = cmd.Usage()
 				return
 			}
 			info.TemplateIDs = args

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -361,6 +361,9 @@ var sandboxTemplatePublishDocument string
 //go:embed sandbox_template_unpublish.md
 var sandboxTemplateUnpublishDocument string
 
+//go:embed sandbox_template_config.md
+var sandboxTemplateConfigDocument string
+
 //go:embed saveas.md
 var saveAsDocument string
 
@@ -494,6 +497,7 @@ const (
 	SandboxTemplateListType        = "sandbox_template_list"
 	SandboxTemplatePublishType     = "sandbox_template_publish"
 	SandboxTemplateUnpublishType   = "sandbox_template_unpublish"
+	SandboxTemplateConfigType      = "sandbox_template_config"
 	SaveAsType                     = "saveas"
 	ShareCpType                    = "share-cp"
 	ShareLsType                    = "share-ls"
@@ -602,6 +606,7 @@ func init() {
 	addCmdDocumentInfo(SandboxTemplateListType, sandboxTemplateListDocument)
 	addCmdDocumentInfo(SandboxTemplatePublishType, sandboxTemplatePublishDocument)
 	addCmdDocumentInfo(SandboxTemplateUnpublishType, sandboxTemplateUnpublishDocument)
+	addCmdDocumentInfo(SandboxTemplateConfigType, sandboxTemplateConfigDocument)
 	addCmdDocumentInfo(SaveAsType, saveAsDocument)
 	addCmdDocumentInfo(ShareCpType, shareCpDocument)
 	addCmdDocumentInfo(ShareLsType, shareLsDocument)

--- a/docs/sandbox_template.md
+++ b/docs/sandbox_template.md
@@ -25,7 +25,7 @@ template 的子命令有：
 * list（ls）：列出模板
 * get（gt）：查看模板详情
 * delete（dl）：删除模板
-* build（bd）：创建并构建模板
+* build（bd）：创建并构建模板，支持 `qshell.sandbox.toml` 配置文件
 * builds（bds）：查看模板构建状态
 * publish（pb）：发布模板（设为公开）
 * unpublish（upb）：取消发布模板（设为私有）
@@ -56,19 +56,31 @@ qshell sandbox template build --name my-template --from-image ubuntu:22.04 --wai
 qshell sbx tpl bd --name my-template --from-image ubuntu:22.04 --wait
 ```
 
-5. 查看构建状态
+5. 使用当前目录的 `qshell.sandbox.toml` 构建模板
+```
+qshell sandbox template build --wait
+qshell sbx tpl bd --wait
+```
+
+6. 查看配置文件中的模板详情
+```
+qshell sandbox template get
+qshell sbx tpl gt
+```
+
+7. 查看构建状态
 ```
 qshell sandbox template builds tmpl-xxxxxxxxxxxx build-xxxxxxxxxxxx
 qshell sbx tpl bds tmpl-xxxxxxxxxxxx build-xxxxxxxxxxxx
 ```
 
-6. 发布/取消发布模板
+8. 发布/取消发布模板
 ```
 qshell sandbox template publish tmpl-xxxxxxxxxxxx -y
 qshell sandbox template unpublish tmpl-xxxxxxxxxxxx -y
 ```
 
-7. 初始化模板项目
+9. 初始化模板项目
 ```
 qshell sandbox template init
 qshell sandbox template init --name my-template --language go

--- a/docs/sandbox_template_build.md
+++ b/docs/sandbox_template_build.md
@@ -1,7 +1,9 @@
 # 简介
 `sandbox template build`（别名 `bd`）创建新模板并触发构建，或对已有模板重新构建。
 
-**创建新模板** 支持三种构建模式：`--from-image` 基于 Docker 镜像、`--from-template` 基于已有模板、`--dockerfile` 基于 Dockerfile（v2 构建系统）。
+**创建新模板** 支持三种基础构建模式：`--from-image` 基于 Docker 镜像、`--from-template` 基于已有模板、`--dockerfile` 基于 Dockerfile（v2 构建系统）。
+
+`--dockerfile` 也可以和 `--from-template` 或 `--from-image` 组合使用，用选定的基础环境作为 base，再应用 Dockerfile 中的 `RUN` / `COPY` / `ENV` 等增量步骤。和 `--from-template` 组合时，Dockerfile 里的 `FROM` 会被解析但不会作为真实基础镜像。
 
 **重新构建已有模板**（`--template-id`）必须提供 `--dockerfile`——服务端 rebuild 接口要求在请求体中携带 Dockerfile 内容。
 
@@ -27,7 +29,7 @@ $ qshell sandbox template build --doc
 - `--template-id`：已有模板 ID（重新构建时使用，与 --name 二选一，必须同时提供 `--dockerfile`）
 - `--from-image`：基础 Docker 镜像
 - `--from-template`：基础模板
-- `--dockerfile`：Dockerfile 路径（启用 v2 构建系统，自动解析 FROM/RUN/COPY 等指令）
+- `--dockerfile`：Dockerfile 路径（启用 v2 构建系统，自动解析 FROM/RUN/COPY 等指令；可与 --from-template 或 --from-image 组合叠加增量步骤）
 - `--path`：构建上下文目录（默认为 Dockerfile 所在目录，与 --dockerfile 配合使用）
 - `--start-cmd`：构建完成后执行的启动命令（Dockerfile 模式下可从 CMD/ENTRYPOINT 自动提取）
 - `--ready-cmd`：就绪检查命令（Dockerfile 模式下默认为 "sleep 20"）
@@ -54,22 +56,29 @@ $ qshell sbx tpl bd --name my-template --dockerfile ./Dockerfile --wait
 $ qshell sandbox template build --name my-template --dockerfile ./docker/Dockerfile --path ./src --wait
 ```
 
-4. 重新构建已有模板（rebuild 必须提供 Dockerfile）
+4. 基于已有模板构建，并叠加 Dockerfile 步骤
+```
+$ qshell sandbox template build --name claude --from-template agents-base --dockerfile ./Dockerfile --wait
+```
+
+这种模式下实际 base 来自 `agents-base`，Dockerfile 里的 `FROM` 仅用于兼容 Dockerfile 解析，不会触发基础镜像拉取。
+
+5. 重新构建已有模板（rebuild 必须提供 Dockerfile）
 ```
 $ qshell sandbox template build --template-id tmpl-xxxxxxxxxxxx --dockerfile ./Dockerfile --wait
 ```
 
-5. 使用 Dockerfile 重新构建已有模板（忽略缓存）
+6. 使用 Dockerfile 重新构建已有模板（忽略缓存）
 ```
 $ qshell sandbox template build --template-id tmpl-xxxxxxxxxxxx --dockerfile ./Dockerfile --no-cache --wait
 ```
 
-6. 强制完整构建（忽略缓存）
+7. 强制完整构建（忽略缓存）
 ```
 $ qshell sandbox template build --template-id tmpl-xxxxxxxxxxxx --dockerfile ./Dockerfile --no-cache --wait
 ```
 
-7. 指定启动命令和资源配置
+8. 指定启动命令和资源配置
 ```
 $ qshell sandbox template build --name my-app --from-image node:18 --start-cmd "npm start" --cpu 2 --memory 1024 --wait
 ```

--- a/docs/sandbox_template_build.md
+++ b/docs/sandbox_template_build.md
@@ -73,3 +73,17 @@ $ qshell sandbox template build --template-id tmpl-xxxxxxxxxxxx --dockerfile ./D
 ```
 $ qshell sandbox template build --name my-app --from-image node:18 --start-cmd "npm start" --cpu 2 --memory 1024 --wait
 ```
+
+## 配置文件支持
+
+`build` 命令支持从 `qshell.sandbox.toml` 读取参数。详见
+[qshell.sandbox.toml 文档](./sandbox_template_config.md)。
+
+示例：
+```bash
+# 当前目录有 qshell.sandbox.toml
+qshell sandbox template build --wait
+
+# 显式指定路径
+qshell sandbox template build --config ./configs/prod.toml --wait
+```

--- a/docs/sandbox_template_config.md
+++ b/docs/sandbox_template_config.md
@@ -59,11 +59,6 @@ no_cache = false
 
 `from_template + dockerfile` 适合在统一基础模板上叠加少量依赖，例如多个 agent 模板共用一个 `agents-base`。
 
-### bool 字段的已知限制
-
-Go flag 无法区分「用户显式传入 `--flag=false`」和「用户没传 `--flag`」。如果配置文件中
-`no_cache = true`，仅通过 CLI 无法把它重置为 false——需要直接修改配置文件。
-
 ## 查找规则
 
 1. `--config <path>` 显式指定路径（仅 `build` 命令支持）
@@ -73,6 +68,7 @@ Go flag 无法区分「用户显式传入 `--flag=false`」和「用户没传 `-
 ## 自动回写行为
 
 - 首次构建（配置文件存在、`template_id` 为空）成功后，qshell 自动把新的 `template_id` 写入文件
+- 未指定 `--wait` 时，在构建成功启动后回写；指定 `--wait` 时，在构建完成且状态为 `ready` 后回写
 - 回写会替换已有的 `template_id` 赋值行（无论原值是否为空），或在文件头插入一行
 - 注释、字段顺序、空白均保留
 - 回写完成后 stdout 打印：`Written template_id to <path> (please commit this file)`

--- a/docs/sandbox_template_config.md
+++ b/docs/sandbox_template_config.md
@@ -1,0 +1,102 @@
+# qshell.sandbox.toml — 模板配置文件
+
+`qshell sandbox template` 系列命令支持从项目根目录读取 `qshell.sandbox.toml`，
+持久化模板参数并自动管理 `template_id`，方便团队协作与 CI 集成。
+
+## 完整字段说明
+
+```toml
+# 模板身份（template_id 由 qshell 首次构建后自动回写，勿手动修改）
+template_id = "tmpl-xxxxxxxxxxxx"
+name        = "claude"
+
+# 构建输入（dockerfile / from_image / from_template 三选一）
+dockerfile    = "./Dockerfile"
+path          = "."
+from_image    = ""
+from_template = ""
+
+# 运行时
+start_cmd = "/root/.jupyter/start-up.sh"
+ready_cmd = ""
+
+# 资源
+cpu_count = 2
+memory_mb = 2048
+
+# 构建选项
+no_cache = false
+```
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| template_id | string | 模板 ID，首次构建后自动回写 |
+| name | string | 模板名称（仅创建时使用） |
+| dockerfile | string | Dockerfile 路径 |
+| path | string | 构建上下文目录 |
+| from_image | string | 基础 Docker 镜像 |
+| from_template | string | 基础模板 |
+| start_cmd | string | 容器启动命令 |
+| ready_cmd | string | 就绪检查命令 |
+| cpu_count | int | CPU 核数 |
+| memory_mb | int | 内存（MiB） |
+| no_cache | bool | 强制忽略缓存 |
+
+## 优先级
+
+`CLI flag > 配置文件 > 内置默认值`
+
+同时提供时，CLI 会覆盖配置文件，并在 stderr 打印一次覆盖提示。
+
+### bool 字段的已知限制
+
+Go flag 无法区分「用户显式传入 `--flag=false`」和「用户没传 `--flag`」。如果配置文件中
+`no_cache = true`，仅通过 CLI 无法把它重置为 false——需要直接修改配置文件。
+
+## 查找规则
+
+1. `--config <path>` 显式指定路径（仅 `build` 命令支持）
+2. 当前工作目录下的 `qshell.sandbox.toml`
+3. 未找到时按纯 CLI 模式运行（向后兼容）
+
+## 自动回写行为
+
+- 首次构建（配置文件存在、`template_id` 为空）成功后，qshell 自动把新的 `template_id` 写入文件
+- 回写会替换已有的 `template_id` 赋值行（无论原值是否为空），或在文件头插入一行
+- 注释、字段顺序、空白均保留
+- 回写完成后 stdout 打印：`Written template_id to <path> (please commit this file)`
+
+## 团队协作约定
+
+将 `qshell.sandbox.toml` 加入版本控制：
+- 团队成员克隆仓库后直接 `qshell sandbox template build` 即可重建同一模板
+- CI 脚本只需一行命令，无需维护散落的参数
+- 首次 commit 由构建者完成；后续通常无需修改（除非切换模板）
+
+## 示例：最小项目
+
+```
+my-template/
+├── Dockerfile
+└── qshell.sandbox.toml
+```
+
+`qshell.sandbox.toml`:
+```toml
+name = "my-template"
+dockerfile = "./Dockerfile"
+cpu_count = 2
+memory_mb = 2048
+```
+
+运行：
+```bash
+qshell sandbox template build --wait
+# 构建完成后，qshell.sandbox.toml 中 template_id 已被回写
+git add qshell.sandbox.toml && git commit -m "chore: record template_id"
+```
+
+下次重建：
+```bash
+qshell sandbox template build --wait  # 幂等，不再 409
+```

--- a/docs/sandbox_template_config.md
+++ b/docs/sandbox_template_config.md
@@ -10,7 +10,7 @@
 template_id = "tmpl-xxxxxxxxxxxx"
 name        = "claude"
 
-# 构建输入（dockerfile / from_image / from_template 三选一）
+# 构建输入
 dockerfile    = "./Dockerfile"
 path          = "."
 from_image    = ""
@@ -47,6 +47,17 @@ no_cache = false
 `CLI flag > 配置文件 > 内置默认值`
 
 同时提供时，CLI 会覆盖配置文件，并在 stderr 打印一次覆盖提示。
+
+## 构建输入组合
+
+`from_image` 和 `from_template` 二选一，不能同时设置。
+
+`dockerfile` 可以单独使用，也可以和 `from_image` 或 `from_template` 组合使用：
+- 只有 `dockerfile`：使用 Dockerfile 中的 `FROM` 作为基础镜像。
+- `from_image + dockerfile`：使用 `from_image` 作为基础镜像，Dockerfile 中的 `FROM` 会被覆盖。
+- `from_template + dockerfile`：使用 `from_template` 作为基础模板，Dockerfile 中的 `FROM` 会被解析但不会作为真实基础镜像。
+
+`from_template + dockerfile` 适合在统一基础模板上叠加少量依赖，例如多个 agent 模板共用一个 `agents-base`。
 
 ### bool 字段的已知限制
 

--- a/docs/sandbox_template_delete.md
+++ b/docs/sandbox_template_delete.md
@@ -17,7 +17,7 @@ $ qshell sandbox template delete --doc
 需要配置 `QINIU_API_KEY` 或 `E2B_API_KEY` 环境变量。
 
 # 参数
-- `templateIDs`：一个或多个模板 ID（与 `--select` 二选一）
+- `templateIDs`：一个或多个模板 ID。未传入且未使用 `--select` 时，自动读取当前目录 `qshell.sandbox.toml` 中的 `template_id`
 - `-y, --yes`：跳过确认提示
 - `-s, --select`：交互式选择模板进行删除
 
@@ -42,4 +42,10 @@ $ qshell sandbox template delete tmpl-aaa tmpl-bbb -y
 ```
 $ qshell sandbox template delete -s
 $ qshell sbx tpl dl -s
+```
+
+5. 删除当前目录配置文件对应的模板
+```
+$ qshell sandbox template delete -y
+$ qshell sbx tpl dl -y
 ```

--- a/docs/sandbox_template_get.md
+++ b/docs/sandbox_template_get.md
@@ -3,8 +3,8 @@
 
 # 格式
 ```
-qshell sandbox template get <templateID>
-qshell sbx tpl gt <templateID>
+qshell sandbox template get [templateID]
+qshell sbx tpl gt [templateID]
 ```
 
 # 帮助文档
@@ -17,10 +17,17 @@ $ qshell sandbox template get --doc
 需要配置 `QINIU_API_KEY` 或 `E2B_API_KEY` 环境变量。
 
 # 参数
-- `templateID`：模板 ID（必填）
+- `templateID`：模板 ID。未传入时，自动读取当前目录 `qshell.sandbox.toml` 中的 `template_id`
 
 # 示例
+1. 通过参数查看模板详情
 ```
 $ qshell sandbox template get tmpl-xxxxxxxxxxxx
 $ qshell sbx tpl gt tmpl-xxxxxxxxxxxx
+```
+
+2. 读取当前目录 `qshell.sandbox.toml` 中的 `template_id`
+```
+$ qshell sandbox template get
+$ qshell sbx tpl gt
 ```

--- a/docs/sandbox_template_publish.md
+++ b/docs/sandbox_template_publish.md
@@ -17,7 +17,7 @@ $ qshell sandbox template publish --doc
 需要配置 `QINIU_API_KEY` 或 `E2B_API_KEY` 环境变量。
 
 # 参数
-- `templateIDs`：一个或多个模板 ID（与 `--select` 二选一）
+- `templateIDs`：一个或多个模板 ID。未传入且未使用 `--select` 时，自动读取当前目录 `qshell.sandbox.toml` 中的 `template_id`
 - `-y, --yes`：跳过确认提示
 - `-s, --select`：交互式选择模板
 
@@ -36,4 +36,10 @@ $ qshell sandbox template publish tmpl-aaa tmpl-bbb -y
 3. 交互式选择发布
 ```
 $ qshell sandbox template publish -s
+```
+
+4. 发布当前目录配置文件对应的模板
+```
+$ qshell sandbox template publish -y
+$ qshell sbx tpl pb -y
 ```

--- a/docs/sandbox_template_unpublish.md
+++ b/docs/sandbox_template_unpublish.md
@@ -17,7 +17,7 @@ $ qshell sandbox template unpublish --doc
 需要配置 `QINIU_API_KEY` 或 `E2B_API_KEY` 环境变量。
 
 # 参数
-- `templateIDs`：一个或多个模板 ID（与 `--select` 二选一）
+- `templateIDs`：一个或多个模板 ID。未传入且未使用 `--select` 时，自动读取当前目录 `qshell.sandbox.toml` 中的 `template_id`
 - `-y, --yes`：跳过确认提示
 - `-s, --select`：交互式选择模板
 
@@ -36,4 +36,10 @@ $ qshell sandbox template unpublish tmpl-aaa tmpl-bbb -y
 3. 交互式选择
 ```
 $ qshell sandbox template unpublish -s
+```
+
+4. 取消发布当前目录配置文件对应的模板
+```
+$ qshell sandbox template unpublish -y
+$ qshell sbx tpl upb -y
 ```

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/qiniu/qshell/v2
 
 require (
+	github.com/BurntSushi/toml v1.3.2
 	github.com/aliyun/aliyun-oss-go-sdk v2.1.6+incompatible
 	github.com/astaxie/beego v1.12.3
 	github.com/aws/aws-sdk-go v1.37.31
@@ -21,7 +22,6 @@ require (
 
 require (
 	connectrpc.com/connect v1.18.1 // indirect
-	github.com/BurntSushi/toml v1.3.2 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.1.1 // indirect
 	github.com/alex-ant/gomath v0.0.0-20160516115720-89013a210a82 // indirect

--- a/iqshell/sandbox/template/config/config.go
+++ b/iqshell/sandbox/template/config/config.go
@@ -1,0 +1,53 @@
+// Package config 处理 qshell.sandbox.toml 配置文件的加载、合并与回写。
+package config
+
+// DefaultFileName 是模板配置文件的默认文件名。
+const DefaultFileName = "qshell.sandbox.toml"
+
+// FileConfig 对应 qshell.sandbox.toml 中的所有可配置字段。
+// 所有字段均为可选：未设置时回退到 CLI 参数或内置默认值。
+type FileConfig struct {
+	// TemplateID 是模板 ID，首次构建后由 qshell 自动回写。
+	TemplateID string `toml:"template_id"`
+
+	// Name 是模板名称，仅首次构建（未设置 TemplateID 时）生效。
+	Name string `toml:"name"`
+
+	// Dockerfile 是 Dockerfile 路径，启用 v2 构建。
+	Dockerfile string `toml:"dockerfile"`
+
+	// Path 是构建上下文目录，默认为 Dockerfile 所在目录。
+	Path string `toml:"path"`
+
+	// FromImage 是基础 Docker 镜像。
+	FromImage string `toml:"from_image"`
+
+	// FromTemplate 是基础模板。
+	FromTemplate string `toml:"from_template"`
+
+	// StartCmd 是容器启动命令。
+	StartCmd string `toml:"start_cmd"`
+
+	// ReadyCmd 是就绪检查命令。
+	ReadyCmd string `toml:"ready_cmd"`
+
+	// CPUCount 是沙箱 CPU 核数。
+	CPUCount int32 `toml:"cpu_count"`
+
+	// MemoryMB 是沙箱内存大小（MiB）。
+	MemoryMB int32 `toml:"memory_mb"`
+
+	// NoCache 强制完整构建，忽略缓存。
+	NoCache bool `toml:"no_cache"`
+
+	// sourcePath 记录配置文件的绝对路径，用于回写。未导出。
+	sourcePath string
+
+	// defined 记录 TOML 文件中显式定义的字段 key 集合。未导出。
+	defined map[string]bool
+}
+
+// SourcePath 返回配置来源文件的绝对路径，未从文件加载时返回空字符串。
+func (c *FileConfig) SourcePath() string {
+	return c.sourcePath
+}

--- a/iqshell/sandbox/template/config/config_test.go
+++ b/iqshell/sandbox/template/config/config_test.go
@@ -133,7 +133,7 @@ func TestApplyTo_IdenticalValuesNoOverrideReport(t *testing.T) {
 func TestApplyTo_BoolDefinedFillsZero(t *testing.T) {
 	// 文件显式定义 no_cache = true，dst 为零值 → 应用文件值
 	cfg := &FileConfig{NoCache: true, defined: map[string]bool{"no_cache": true}}
-	dst := BuildFields{NoCache: false}
+	dst := BuildFields{NoCache: false, NoCacheChanged: false}
 	overrides := cfg.ApplyTo(&dst)
 	assert.True(t, dst.NoCache)
 	assert.Empty(t, overrides)
@@ -151,9 +151,18 @@ func TestApplyTo_BoolNotDefinedIgnored(t *testing.T) {
 func TestApplyTo_BoolDefinedCLITrueWins(t *testing.T) {
 	// 文件 no_cache = false，CLI no_cache = true → CLI 胜出并报告覆盖
 	cfg := &FileConfig{NoCache: false, defined: map[string]bool{"no_cache": true}}
-	dst := BuildFields{NoCache: true}
+	dst := BuildFields{NoCache: true, NoCacheChanged: true}
 	overrides := cfg.ApplyTo(&dst)
 	assert.True(t, dst.NoCache)
+	assert.ElementsMatch(t, []string{"no_cache"}, overrides)
+}
+
+func TestApplyTo_BoolDefinedCLIFalseWins(t *testing.T) {
+	// 文件 no_cache = true，CLI 显式 no_cache=false → CLI 胜出并报告覆盖。
+	cfg := &FileConfig{NoCache: true, defined: map[string]bool{"no_cache": true}}
+	dst := BuildFields{NoCache: false, NoCacheChanged: true}
+	overrides := cfg.ApplyTo(&dst)
+	assert.False(t, dst.NoCache)
 	assert.ElementsMatch(t, []string{"no_cache"}, overrides)
 }
 
@@ -217,7 +226,7 @@ name = "demo"
 func TestWriteTemplateID_PreservesIndentation(t *testing.T) {
 	dir := t.TempDir()
 	p := filepath.Join(dir, "qshell.sandbox.toml")
-	orig := "[section]\n    template_id = \"old\"\n    name = \"demo\"\n"
+	orig := "    template_id = \"old\"\nname = \"demo\"\n"
 	require.NoError(t, os.WriteFile(p, []byte(orig), 0644))
 
 	err := WriteTemplateID(p, "tmpl-new")
@@ -226,6 +235,20 @@ func TestWriteTemplateID_PreservesIndentation(t *testing.T) {
 	got, err := os.ReadFile(p)
 	require.NoError(t, err)
 	assert.Contains(t, string(got), "    template_id = \"tmpl-new\"")
+}
+
+func TestWriteTemplateID_DoesNotReplaceTableField(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "qshell.sandbox.toml")
+	orig := "[section]\n    template_id = \"section-value\"\nname = \"demo\"\n"
+	require.NoError(t, os.WriteFile(p, []byte(orig), 0644))
+
+	err := WriteTemplateID(p, "tmpl-new")
+	require.NoError(t, err)
+
+	got, err := os.ReadFile(p)
+	require.NoError(t, err)
+	assert.Equal(t, "template_id = \"tmpl-new\"\n[section]\n    template_id = \"section-value\"\nname = \"demo\"\n", string(got))
 }
 
 func TestWriteTemplateID_PreservesCRLF(t *testing.T) {

--- a/iqshell/sandbox/template/config/config_test.go
+++ b/iqshell/sandbox/template/config/config_test.go
@@ -1,0 +1,256 @@
+//go:build unit
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoad_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	cfg, err := Load(filepath.Join(dir, "nope.toml"))
+	assert.NoError(t, err)
+	assert.Nil(t, cfg)
+}
+
+func TestLoad_ValidFile(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "qshell.sandbox.toml")
+	content := `template_id = "tmpl-abc"
+name = "demo"
+dockerfile = "./Dockerfile"
+cpu_count = 2
+memory_mb = 2048
+no_cache = true
+`
+	require.NoError(t, os.WriteFile(p, []byte(content), 0644))
+
+	cfg, err := Load(p)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.Equal(t, "tmpl-abc", cfg.TemplateID)
+	assert.Equal(t, "demo", cfg.Name)
+	assert.Equal(t, "./Dockerfile", cfg.Dockerfile)
+	assert.Equal(t, int32(2), cfg.CPUCount)
+	assert.Equal(t, int32(2048), cfg.MemoryMB)
+	assert.True(t, cfg.NoCache)
+	assert.Equal(t, p, cfg.SourcePath())
+}
+
+func TestLoad_InvalidTOML(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "qshell.sandbox.toml")
+	require.NoError(t, os.WriteFile(p, []byte("this is = not = valid"), 0644))
+
+	cfg, err := Load(p)
+	assert.Error(t, err)
+	assert.Nil(t, cfg)
+}
+
+func TestFindInCwd_Found(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, DefaultFileName)
+	require.NoError(t, os.WriteFile(p, []byte(""), 0644))
+
+	got, err := FindInDir(dir)
+	require.NoError(t, err)
+	assert.Equal(t, p, got)
+}
+
+func TestFindInCwd_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	got, err := FindInDir(dir)
+	assert.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestApplyTo_FileOnly(t *testing.T) {
+	cfg := &FileConfig{
+		TemplateID: "tmpl-x",
+		Name:       "demo",
+		Dockerfile: "./Dockerfile",
+		CPUCount:   2,
+		MemoryMB:   2048,
+		NoCache:    true,
+		defined:    map[string]bool{"no_cache": true},
+	}
+	dst := BuildFields{}
+	overrides := cfg.ApplyTo(&dst)
+	assert.Equal(t, "tmpl-x", dst.TemplateID)
+	assert.Equal(t, "demo", dst.Name)
+	assert.Equal(t, "./Dockerfile", dst.Dockerfile)
+	assert.Equal(t, int32(2), dst.CPUCount)
+	assert.Equal(t, int32(2048), dst.MemoryMB)
+	assert.True(t, dst.NoCache)
+	assert.Empty(t, overrides)
+}
+
+func TestApplyTo_CLIOverride(t *testing.T) {
+	cfg := &FileConfig{
+		Name:     "from-file",
+		CPUCount: 2,
+		NoCache:  false,
+	}
+	dst := BuildFields{
+		Name:     "from-cli",
+		CPUCount: 4,
+		NoCache:  true,
+	}
+	overrides := cfg.ApplyTo(&dst)
+	assert.Equal(t, "from-cli", dst.Name)
+	assert.Equal(t, int32(4), dst.CPUCount)
+	assert.True(t, dst.NoCache)
+	assert.ElementsMatch(t, []string{"name", "cpu_count"}, overrides)
+}
+
+func TestApplyTo_MixedFill(t *testing.T) {
+	cfg := &FileConfig{
+		Dockerfile: "./Dockerfile",
+		StartCmd:   "/start.sh",
+	}
+	dst := BuildFields{
+		Name: "from-cli",
+	}
+	overrides := cfg.ApplyTo(&dst)
+	assert.Equal(t, "from-cli", dst.Name)
+	assert.Equal(t, "./Dockerfile", dst.Dockerfile)
+	assert.Equal(t, "/start.sh", dst.StartCmd)
+	assert.Empty(t, overrides)
+}
+
+func TestApplyTo_IdenticalValuesNoOverrideReport(t *testing.T) {
+	cfg := &FileConfig{Name: "same", CPUCount: 2}
+	dst := BuildFields{Name: "same", CPUCount: 2}
+	overrides := cfg.ApplyTo(&dst)
+	assert.Empty(t, overrides)
+}
+
+func TestApplyTo_BoolDefinedFillsZero(t *testing.T) {
+	// 文件显式定义 no_cache = true，dst 为零值 → 应用文件值
+	cfg := &FileConfig{NoCache: true, defined: map[string]bool{"no_cache": true}}
+	dst := BuildFields{NoCache: false}
+	overrides := cfg.ApplyTo(&dst)
+	assert.True(t, dst.NoCache)
+	assert.Empty(t, overrides)
+}
+
+func TestApplyTo_BoolNotDefinedIgnored(t *testing.T) {
+	// 文件未定义 no_cache（未经 Load 构造），即便结构体零值为 false 也不应覆盖
+	cfg := &FileConfig{NoCache: false}
+	dst := BuildFields{NoCache: true}
+	overrides := cfg.ApplyTo(&dst)
+	assert.True(t, dst.NoCache, "CLI-true 在文件未定义 no_cache 时保留")
+	assert.Empty(t, overrides)
+}
+
+func TestApplyTo_BoolDefinedCLITrueWins(t *testing.T) {
+	// 文件 no_cache = false，CLI no_cache = true → CLI 胜出并报告覆盖
+	cfg := &FileConfig{NoCache: false, defined: map[string]bool{"no_cache": true}}
+	dst := BuildFields{NoCache: true}
+	overrides := cfg.ApplyTo(&dst)
+	assert.True(t, dst.NoCache)
+	assert.ElementsMatch(t, []string{"no_cache"}, overrides)
+}
+
+func TestWriteTemplateID_ReplaceExisting(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "qshell.sandbox.toml")
+	orig := `# comment kept
+template_id = ""
+name = "demo"
+dockerfile = "./Dockerfile"
+`
+	require.NoError(t, os.WriteFile(p, []byte(orig), 0644))
+
+	err := WriteTemplateID(p, "tmpl-new")
+	require.NoError(t, err)
+
+	got, err := os.ReadFile(p)
+	require.NoError(t, err)
+	expected := `# comment kept
+template_id = "tmpl-new"
+name = "demo"
+dockerfile = "./Dockerfile"
+`
+	assert.Equal(t, expected, string(got))
+}
+
+func TestWriteTemplateID_InsertWhenMissing(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "qshell.sandbox.toml")
+	orig := `name = "demo"
+dockerfile = "./Dockerfile"
+`
+	require.NoError(t, os.WriteFile(p, []byte(orig), 0644))
+
+	err := WriteTemplateID(p, "tmpl-new")
+	require.NoError(t, err)
+
+	got, err := os.ReadFile(p)
+	require.NoError(t, err)
+	assert.Contains(t, string(got), `template_id = "tmpl-new"`)
+	assert.Contains(t, string(got), `name = "demo"`)
+}
+
+func TestWriteTemplateID_PreservesCommentedLine(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "qshell.sandbox.toml")
+	orig := `# template_id = "old"
+name = "demo"
+`
+	require.NoError(t, os.WriteFile(p, []byte(orig), 0644))
+
+	err := WriteTemplateID(p, "tmpl-new")
+	require.NoError(t, err)
+
+	got, err := os.ReadFile(p)
+	require.NoError(t, err)
+	assert.Contains(t, string(got), `# template_id = "old"`)
+	assert.Contains(t, string(got), `template_id = "tmpl-new"`)
+}
+
+func TestWriteTemplateID_PreservesIndentation(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "qshell.sandbox.toml")
+	orig := "[section]\n    template_id = \"old\"\n    name = \"demo\"\n"
+	require.NoError(t, os.WriteFile(p, []byte(orig), 0644))
+
+	err := WriteTemplateID(p, "tmpl-new")
+	require.NoError(t, err)
+
+	got, err := os.ReadFile(p)
+	require.NoError(t, err)
+	assert.Contains(t, string(got), "    template_id = \"tmpl-new\"")
+}
+
+func TestWriteTemplateID_PreservesCRLF(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "qshell.sandbox.toml")
+	orig := "template_id = \"\"\r\nname = \"demo\"\r\n"
+	require.NoError(t, os.WriteFile(p, []byte(orig), 0644))
+
+	err := WriteTemplateID(p, "tmpl-new")
+	require.NoError(t, err)
+
+	got, err := os.ReadFile(p)
+	require.NoError(t, err)
+	assert.Equal(t, "template_id = \"tmpl-new\"\r\nname = \"demo\"\r\n", string(got))
+}
+
+func TestWriteTemplateID_PreservesPermissions(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "qshell.sandbox.toml")
+	require.NoError(t, os.WriteFile(p, []byte("name = \"demo\"\n"), 0600))
+
+	err := WriteTemplateID(p, "tmpl-new")
+	require.NoError(t, err)
+
+	info, err := os.Stat(p)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
+}

--- a/iqshell/sandbox/template/config/loader.go
+++ b/iqshell/sandbox/template/config/loader.go
@@ -1,0 +1,78 @@
+package config
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/BurntSushi/toml"
+)
+
+// Load 从给定路径加载并解析 TOML 配置文件。
+// 文件不存在时返回 (nil, nil)；解析失败时返回错误。
+func Load(path string) (*FileConfig, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("resolve config path: %w", err)
+	}
+
+	data, err := os.ReadFile(abs)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read config %s: %w", abs, err)
+	}
+
+	cfg := &FileConfig{}
+	md, err := toml.NewDecoder(bytes.NewReader(data)).Decode(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("parse config %s: %w", abs, err)
+	}
+	cfg.defined = make(map[string]bool, len(md.Keys()))
+	for _, k := range md.Keys() {
+		cfg.defined[k.String()] = true
+	}
+	cfg.sourcePath = abs
+	return cfg, nil
+}
+
+// FindInDir 在指定目录中查找 DefaultFileName。
+// 找到返回绝对路径；未找到返回 ("", nil)。
+func FindInDir(dir string) (string, error) {
+	p := filepath.Join(dir, DefaultFileName)
+	info, err := os.Stat(p)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", nil
+		}
+		return "", fmt.Errorf("stat %s: %w", p, err)
+	}
+	if info.IsDir() {
+		return "", nil
+	}
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return "", fmt.Errorf("resolve %s: %w", p, err)
+	}
+	return abs, nil
+}
+
+// LoadFromCwd 在当前工作目录查找并加载默认配置文件。
+// 未找到返回 (nil, nil)，方便调用方判断是否存在。
+func LoadFromCwd() (*FileConfig, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, fmt.Errorf("getwd: %w", err)
+	}
+	p, err := FindInDir(cwd)
+	if err != nil {
+		return nil, err
+	}
+	if p == "" {
+		return nil, nil
+	}
+	return Load(p)
+}

--- a/iqshell/sandbox/template/config/merge.go
+++ b/iqshell/sandbox/template/config/merge.go
@@ -26,6 +26,8 @@ type BuildFields struct {
 	MemoryMB int32
 	// NoCache 强制完整构建，忽略缓存。
 	NoCache bool
+	// NoCacheChanged 表示 CLI 是否显式设置了 --no-cache。
+	NoCacheChanged bool
 }
 
 // ApplyTo 将 FileConfig 的值合并到 dst 中：仅当 dst 字段为零值时才采用 file 值。
@@ -65,9 +67,10 @@ func (c *FileConfig) ApplyTo(dst *BuildFields) []string {
 		if *dstVal == fileVal {
 			return
 		}
-		// 文件值与 dst 不同。由于 Go flag 无法区分 "CLI 显式传 false" 与
-		// "未传默认 false"，策略为：dst 为零值时采用文件值；dst 为 true 时
-		// CLI 胜出并报告覆盖。
+		if dst.NoCacheChanged {
+			overrides = append(overrides, key)
+			return
+		}
 		if !*dstVal {
 			*dstVal = fileVal
 			return

--- a/iqshell/sandbox/template/config/merge.go
+++ b/iqshell/sandbox/template/config/merge.go
@@ -1,0 +1,91 @@
+package config
+
+// BuildFields 是 operations.BuildInfo 中可由配置文件提供的字段子集。
+// 单独定义以避免 config 包依赖 operations 包（解决循环依赖）。
+// operations.Build 在调用前将 BuildInfo 拷贝为 BuildFields，调用后拷贝回。
+type BuildFields struct {
+	// TemplateID 是模板 ID。
+	TemplateID string
+	// Name 是模板名称。
+	Name string
+	// Dockerfile 是 Dockerfile 路径。
+	Dockerfile string
+	// Path 是构建上下文目录。
+	Path string
+	// FromImage 是基础 Docker 镜像。
+	FromImage string
+	// FromTemplate 是基础模板。
+	FromTemplate string
+	// StartCmd 是容器启动命令。
+	StartCmd string
+	// ReadyCmd 是就绪检查命令。
+	ReadyCmd string
+	// CPUCount 是沙箱 CPU 核数。
+	CPUCount int32
+	// MemoryMB 是沙箱内存大小（MiB）。
+	MemoryMB int32
+	// NoCache 强制完整构建，忽略缓存。
+	NoCache bool
+}
+
+// ApplyTo 将 FileConfig 的值合并到 dst 中：仅当 dst 字段为零值时才采用 file 值。
+// 返回被 CLI 覆盖（即 dst 已有非零值且与 file 值不同）的 TOML 字段名列表。
+func (c *FileConfig) ApplyTo(dst *BuildFields) []string {
+	var overrides []string
+
+	applyString := func(fileVal string, dstVal *string, key string) {
+		if fileVal == "" {
+			return
+		}
+		if *dstVal == "" {
+			*dstVal = fileVal
+			return
+		}
+		if *dstVal != fileVal {
+			overrides = append(overrides, key)
+		}
+	}
+	applyInt32 := func(fileVal int32, dstVal *int32, key string) {
+		if fileVal == 0 {
+			return
+		}
+		if *dstVal == 0 {
+			*dstVal = fileVal
+			return
+		}
+		if *dstVal != fileVal {
+			overrides = append(overrides, key)
+		}
+	}
+	applyBool := func(fileVal bool, dstVal *bool, key string) {
+		// 未在文件中显式定义时，尊重 CLI 值。
+		if !c.defined[key] {
+			return
+		}
+		if *dstVal == fileVal {
+			return
+		}
+		// 文件值与 dst 不同。由于 Go flag 无法区分 "CLI 显式传 false" 与
+		// "未传默认 false"，策略为：dst 为零值时采用文件值；dst 为 true 时
+		// CLI 胜出并报告覆盖。
+		if !*dstVal {
+			*dstVal = fileVal
+			return
+		}
+		overrides = append(overrides, key)
+	}
+
+	applyString(c.TemplateID, &dst.TemplateID, "template_id")
+	applyString(c.Name, &dst.Name, "name")
+	applyString(c.Dockerfile, &dst.Dockerfile, "dockerfile")
+	applyString(c.Path, &dst.Path, "path")
+	applyString(c.FromImage, &dst.FromImage, "from_image")
+	applyString(c.FromTemplate, &dst.FromTemplate, "from_template")
+	applyString(c.StartCmd, &dst.StartCmd, "start_cmd")
+	applyString(c.ReadyCmd, &dst.ReadyCmd, "ready_cmd")
+	applyInt32(c.CPUCount, &dst.CPUCount, "cpu_count")
+	applyInt32(c.MemoryMB, &dst.MemoryMB, "memory_mb")
+	applyBool(c.NoCache, &dst.NoCache, "no_cache")
+
+	return overrides
+}

--- a/iqshell/sandbox/template/config/writer.go
+++ b/iqshell/sandbox/template/config/writer.go
@@ -35,9 +35,14 @@ func WriteTemplateID(path, templateID string) error {
 	var out bytes.Buffer
 	scanner := bufio.NewScanner(bytes.NewReader(data))
 	replaced := false
+	inRootTable := true
 	for scanner.Scan() {
 		line := scanner.Text()
-		if !replaced && templateIDLineRegex.MatchString(line) && !isCommentLine(line) {
+		trimmed := strings.TrimSpace(line)
+		if !isCommentLine(line) && strings.HasPrefix(trimmed, "[") {
+			inRootTable = false
+		}
+		if inRootTable && !replaced && templateIDLineRegex.MatchString(line) && !isCommentLine(line) {
 			// 保留原行的前导缩进
 			idx := strings.Index(line, "template_id")
 			indent := ""

--- a/iqshell/sandbox/template/config/writer.go
+++ b/iqshell/sandbox/template/config/writer.go
@@ -1,0 +1,81 @@
+package config
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+)
+
+// templateIDLineRegex 匹配未注释的 template_id 赋值行（允许前导空白）。
+var templateIDLineRegex = regexp.MustCompile(`^\s*template_id\s*=`)
+
+// WriteTemplateID 将 template_id 写入指定 TOML 文件。
+// 若文件中已有未注释的 template_id 行，则替换其值；否则在文件头插入一行。
+// 保留文件原有的权限、注释、字段顺序、缩进、换行风格和空白。
+func WriteTemplateID(path, templateID string) error {
+	stat, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat %s: %w", path, err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+
+	// 识别原文件换行风格，回写时保留 CRLF / LF。
+	lineEnd := "\n"
+	if bytes.Contains(data, []byte("\r\n")) {
+		lineEnd = "\r\n"
+	}
+
+	var out bytes.Buffer
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	replaced := false
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !replaced && templateIDLineRegex.MatchString(line) && !isCommentLine(line) {
+			// 保留原行的前导缩进
+			idx := strings.Index(line, "template_id")
+			indent := ""
+			if idx > 0 {
+				indent = line[:idx]
+			}
+			fmt.Fprintf(&out, "%stemplate_id = %q%s", indent, templateID, lineEnd)
+			replaced = true
+			continue
+		}
+		out.WriteString(line)
+		out.WriteString(lineEnd)
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("scan %s: %w", path, err)
+	}
+
+	if !replaced {
+		// 未找到赋值行：在文件头插入
+		var prefix bytes.Buffer
+		fmt.Fprintf(&prefix, "template_id = %q%s", templateID, lineEnd)
+		prefix.Write(out.Bytes())
+		out = prefix
+	}
+
+	// 保持与原文件结尾换行一致
+	final := out.Bytes()
+	if len(data) > 0 && !bytes.HasSuffix(data, []byte(lineEnd)) && bytes.HasSuffix(final, []byte(lineEnd)) {
+		final = final[:len(final)-len(lineEnd)]
+	}
+
+	if err := os.WriteFile(path, final, stat.Mode().Perm()); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+// isCommentLine 判断一行是否以 # 开头（允许前导空白）。
+func isCommentLine(line string) bool {
+	return strings.HasPrefix(strings.TrimLeft(line, " \t"), "#")
+}

--- a/iqshell/sandbox/template/operations/build.go
+++ b/iqshell/sandbox/template/operations/build.go
@@ -46,6 +46,8 @@ type BuildInfo struct {
 
 	// NoCache 强制完整构建，忽略缓存。
 	NoCache bool
+	// NoCacheChanged 表示 CLI 是否显式设置了 --no-cache。
+	NoCacheChanged bool
 
 	// Dockerfile 是 Dockerfile 的路径（启用 v2 Dockerfile 构建）。
 	Dockerfile string
@@ -89,17 +91,18 @@ func Build(info BuildInfo) {
 
 	if cfg != nil {
 		fields := config.BuildFields{
-			TemplateID:   info.TemplateID,
-			Name:         info.Name,
-			Dockerfile:   info.Dockerfile,
-			Path:         info.Path,
-			FromImage:    info.FromImage,
-			FromTemplate: info.FromTemplate,
-			StartCmd:     info.StartCmd,
-			ReadyCmd:     info.ReadyCmd,
-			CPUCount:     info.CPUCount,
-			MemoryMB:     info.MemoryMB,
-			NoCache:      info.NoCache,
+			TemplateID:     info.TemplateID,
+			Name:           info.Name,
+			Dockerfile:     info.Dockerfile,
+			Path:           info.Path,
+			FromImage:      info.FromImage,
+			FromTemplate:   info.FromTemplate,
+			StartCmd:       info.StartCmd,
+			ReadyCmd:       info.ReadyCmd,
+			CPUCount:       info.CPUCount,
+			MemoryMB:       info.MemoryMB,
+			NoCache:        info.NoCache,
+			NoCacheChanged: info.NoCacheChanged,
 		}
 		overrides := cfg.ApplyTo(&fields)
 		info.TemplateID = fields.TemplateID
@@ -160,17 +163,6 @@ func Build(info BuildInfo) {
 		templateID = resp.TemplateID
 		buildID = resp.BuildID
 		sbClient.PrintSuccess("Template %s created (build ID: %s)", templateID, buildID)
-		// 如果配置文件存在、CLI 未提供 TemplateID，则回写。
-		if cfg != nil && noIDBeforeMerge && cfg.SourcePath() != "" {
-			if wErr := config.WriteTemplateID(cfg.SourcePath(), templateID); wErr != nil {
-				// 回写失败仅警告，不中断构建
-				fmt.Fprintf(os.Stderr, "[config] warning: failed to write template_id to %s: %v\n",
-					cfg.SourcePath(), wErr)
-			} else {
-				sbClient.PrintSuccess("Written template_id to %s (please commit this file)",
-					cfg.SourcePath())
-			}
-		}
 	} else {
 		// 对已有模板申请新的 waiting build（对齐 E2B CLI 的 rebuild 流程）：
 		// RebuildTemplate → StartTemplateBuild → WaitForBuild。
@@ -238,6 +230,7 @@ func Build(info BuildInfo) {
 	}
 
 	if !info.Wait {
+		writeTemplateIDToConfigIfNeeded(cfg, noIDBeforeMerge, templateID)
 		fmt.Printf("Build started. Use 'qshell sandbox template builds %s %s' to check status.\n", templateID, buildID)
 		return
 	}
@@ -277,6 +270,7 @@ func Build(info BuildInfo) {
 				sbClient.PrintError("build failed")
 			} else {
 				sbClient.PrintSuccess("Build completed!")
+				writeTemplateIDToConfigIfNeeded(cfg, noIDBeforeMerge, templateID)
 			}
 			fmt.Printf("Template ID:  %s\n", buildInfo.TemplateID)
 			fmt.Printf("Build ID:     %s\n", buildInfo.BuildID)
@@ -295,6 +289,18 @@ func Build(info BuildInfo) {
 		case <-time.After(3 * time.Second):
 		}
 	}
+}
+
+func writeTemplateIDToConfigIfNeeded(cfg *config.FileConfig, noIDBeforeMerge bool, templateID string) {
+	if cfg == nil || !noIDBeforeMerge || cfg.SourcePath() == "" {
+		return
+	}
+	if wErr := config.WriteTemplateID(cfg.SourcePath(), templateID); wErr != nil {
+		fmt.Fprintf(os.Stderr, "[config] warning: failed to write template_id to %s: %v\n",
+			cfg.SourcePath(), wErr)
+		return
+	}
+	sbClient.PrintSuccess("Written template_id to %s (please commit this file)", cfg.SourcePath())
 }
 
 // buildFromDockerfile 处理 v2 Dockerfile 构建流程：

--- a/iqshell/sandbox/template/operations/build.go
+++ b/iqshell/sandbox/template/operations/build.go
@@ -11,6 +11,7 @@ import (
 	"github.com/qiniu/go-sdk/v7/sandbox"
 
 	sbClient "github.com/qiniu/qshell/v2/iqshell/sandbox"
+	"github.com/qiniu/qshell/v2/iqshell/sandbox/template/config"
 	"github.com/qiniu/qshell/v2/iqshell/sandbox/template/dockerfile"
 )
 
@@ -51,12 +52,73 @@ type BuildInfo struct {
 
 	// Path 是构建上下文目录（默认为 Dockerfile 所在目录）。
 	Path string
+
+	// ConfigPath 是 qshell.sandbox.toml 的显式路径。
+	// 为空时自动在当前工作目录查找。
+	ConfigPath string
 }
 
 // Build 创建或重新构建模板。
 // 如果提供了 TemplateID，则对已有模板启动新构建。
 // 否则，使用给定的 Name 创建新模板并启动构建。
 func Build(info BuildInfo) {
+	// 在合并配置前捕获"CLI 未提供 TemplateID"，以便后续判断是否需要回写。
+	noIDBeforeMerge := info.TemplateID == ""
+
+	// 加载配置文件并合并（CLI > file > default）
+	var cfg *config.FileConfig
+	if info.ConfigPath != "" {
+		loaded, cErr := config.Load(info.ConfigPath)
+		if cErr != nil {
+			sbClient.PrintError("load config: %v", cErr)
+			return
+		}
+		if loaded == nil {
+			sbClient.PrintError("config file not found: %s", info.ConfigPath)
+			return
+		}
+		cfg = loaded
+	} else {
+		loaded, cErr := config.LoadFromCwd()
+		if cErr != nil {
+			sbClient.PrintError("load config: %v", cErr)
+			return
+		}
+		cfg = loaded
+	}
+
+	if cfg != nil {
+		fields := config.BuildFields{
+			TemplateID:   info.TemplateID,
+			Name:         info.Name,
+			Dockerfile:   info.Dockerfile,
+			Path:         info.Path,
+			FromImage:    info.FromImage,
+			FromTemplate: info.FromTemplate,
+			StartCmd:     info.StartCmd,
+			ReadyCmd:     info.ReadyCmd,
+			CPUCount:     info.CPUCount,
+			MemoryMB:     info.MemoryMB,
+			NoCache:      info.NoCache,
+		}
+		overrides := cfg.ApplyTo(&fields)
+		info.TemplateID = fields.TemplateID
+		info.Name = fields.Name
+		info.Dockerfile = fields.Dockerfile
+		info.Path = fields.Path
+		info.FromImage = fields.FromImage
+		info.FromTemplate = fields.FromTemplate
+		info.StartCmd = fields.StartCmd
+		info.ReadyCmd = fields.ReadyCmd
+		info.CPUCount = fields.CPUCount
+		info.MemoryMB = fields.MemoryMB
+		info.NoCache = fields.NoCache
+
+		for _, key := range overrides {
+			fmt.Fprintf(os.Stderr, "[config] CLI overrides %s from %s\n", key, cfg.SourcePath())
+		}
+	}
+
 	client, err := sbClient.NewSandboxClient()
 	if err != nil {
 		sbClient.PrintError("%v", err)
@@ -93,6 +155,17 @@ func Build(info BuildInfo) {
 		templateID = resp.TemplateID
 		buildID = resp.BuildID
 		sbClient.PrintSuccess("Template %s created (build ID: %s)", templateID, buildID)
+		// 如果配置文件存在、CLI 未提供 TemplateID，则回写。
+		if cfg != nil && noIDBeforeMerge && cfg.SourcePath() != "" {
+			if wErr := config.WriteTemplateID(cfg.SourcePath(), templateID); wErr != nil {
+				// 回写失败仅警告，不中断构建
+				fmt.Fprintf(os.Stderr, "[config] warning: failed to write template_id to %s: %v\n",
+					cfg.SourcePath(), wErr)
+			} else {
+				sbClient.PrintSuccess("Written template_id to %s (please commit this file)",
+					cfg.SourcePath())
+			}
+		}
 	} else {
 		// 对已有模板申请新的 waiting build（对齐 E2B CLI 的 rebuild 流程）：
 		// RebuildTemplate → StartTemplateBuild → WaitForBuild。

--- a/iqshell/sandbox/template/operations/build.go
+++ b/iqshell/sandbox/template/operations/build.go
@@ -119,6 +119,11 @@ func Build(info BuildInfo) {
 		}
 	}
 
+	if err := validateBuildSourceSelection(info); err != nil {
+		sbClient.PrintError("%v", err)
+		return
+	}
+
 	client, err := sbClient.NewSandboxClient()
 	if err != nil {
 		sbClient.PrintError("%v", err)
@@ -207,12 +212,6 @@ func Build(info BuildInfo) {
 			return
 		}
 	} else {
-		// 验证构建来源
-		if info.FromImage == "" && info.FromTemplate == "" {
-			sbClient.PrintError("--from-image, --from-template, or --dockerfile is required")
-			return
-		}
-
 		buildParams := sandbox.StartTemplateBuildParams{}
 		if info.FromImage != "" {
 			buildParams.FromImage = &info.FromImage
@@ -360,10 +359,7 @@ func buildFromDockerfile(ctx context.Context, client *sandbox.Client, templateID
 	}
 
 	// 构建参数
-	buildParams := sandbox.StartTemplateBuildParams{
-		FromImage: &result.BaseImage,
-		Steps:     &result.Steps,
-	}
+	buildParams := buildParamsFromDockerfileResult(result, info)
 
 	// 应用来自 Dockerfile 或 CLI 覆盖的启动/就绪命令
 	startCmd := result.StartCmd
@@ -393,6 +389,33 @@ func buildFromDockerfile(ctx context.Context, client *sandbox.Client, templateID
 	}
 
 	return nil
+}
+
+func validateBuildSourceSelection(info BuildInfo) error {
+	if info.FromImage != "" && info.FromTemplate != "" {
+		return fmt.Errorf("cannot specify both --from-image and --from-template")
+	}
+	if info.Dockerfile == "" && info.FromImage == "" && info.FromTemplate == "" {
+		return fmt.Errorf("--from-image, --from-template, or --dockerfile is required")
+	}
+	return nil
+}
+
+func buildParamsFromDockerfileResult(result *dockerfile.ConvertResult, info BuildInfo) sandbox.StartTemplateBuildParams {
+	buildParams := sandbox.StartTemplateBuildParams{
+		Steps: &result.Steps,
+	}
+
+	switch {
+	case info.FromTemplate != "":
+		buildParams.FromTemplate = &info.FromTemplate
+	case info.FromImage != "":
+		buildParams.FromImage = &info.FromImage
+	default:
+		buildParams.FromImage = &result.BaseImage
+	}
+
+	return buildParams
 }
 
 // dockerfileForRebuild 返回 rebuild 请求所需的 Dockerfile 文本。

--- a/iqshell/sandbox/template/operations/build_test.go
+++ b/iqshell/sandbox/template/operations/build_test.go
@@ -1,0 +1,76 @@
+package operations
+
+import (
+	"testing"
+
+	"github.com/qiniu/go-sdk/v7/sandbox"
+	"github.com/stretchr/testify/assert"
+
+	templatedockerfile "github.com/qiniu/qshell/v2/iqshell/sandbox/template/dockerfile"
+)
+
+func TestBuildParamsFromDockerfileResult_UsesFromTemplateAsBase(t *testing.T) {
+	result := &templatedockerfile.ConvertResult{
+		BaseImage: "ignored-from-dockerfile",
+		Steps: []sandbox.TemplateStep{
+			{Type: "RUN", Args: stringSlicePtr("echo hello")},
+		},
+	}
+
+	params := buildParamsFromDockerfileResult(result, BuildInfo{
+		FromTemplate: "agents-base",
+	})
+
+	assert.Nil(t, params.FromImage)
+	assert.NotNil(t, params.FromTemplate)
+	assert.Equal(t, "agents-base", *params.FromTemplate)
+	assert.NotNil(t, params.Steps)
+	assert.Len(t, *params.Steps, 1)
+}
+
+func TestBuildParamsFromDockerfileResult_FromImageOverridesDockerfileBase(t *testing.T) {
+	result := &templatedockerfile.ConvertResult{
+		BaseImage: "dockerfile-base",
+		Steps:     []sandbox.TemplateStep{},
+	}
+
+	params := buildParamsFromDockerfileResult(result, BuildInfo{
+		FromImage: "explicit-base",
+	})
+
+	assert.NotNil(t, params.FromImage)
+	assert.Equal(t, "explicit-base", *params.FromImage)
+	assert.Nil(t, params.FromTemplate)
+}
+
+func TestValidateBuildSourceSelection_RejectsFromImageAndFromTemplate(t *testing.T) {
+	err := validateBuildSourceSelection(BuildInfo{
+		FromImage:    "ubuntu:22.04",
+		FromTemplate: "agents-base",
+	})
+
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "cannot specify both")
+	}
+}
+
+func TestValidateBuildSourceSelection_AllowsDockerfileWithFromTemplate(t *testing.T) {
+	err := validateBuildSourceSelection(BuildInfo{
+		Dockerfile:   "./Dockerfile",
+		FromTemplate: "agents-base",
+	})
+
+	assert.NoError(t, err)
+}
+
+func TestValidateBuildSourceSelection_RequiresSource(t *testing.T) {
+	err := validateBuildSourceSelection(BuildInfo{})
+
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "--from-image")
+	}
+}
+
+func stringSlicePtr(values ...string) *[]string {
+	return &values
+}

--- a/iqshell/sandbox/template/operations/config_fallback.go
+++ b/iqshell/sandbox/template/operations/config_fallback.go
@@ -1,0 +1,25 @@
+package operations
+
+import (
+	"fmt"
+	"os"
+
+	sbClient "github.com/qiniu/qshell/v2/iqshell/sandbox"
+	"github.com/qiniu/qshell/v2/iqshell/sandbox/template/config"
+)
+
+// templateIDFromCwdConfig 在当前工作目录加载 qshell.sandbox.toml，
+// 返回其中的 template_id。加载/解析失败时打印错误并返回 (""，false)。
+// 文件不存在或未包含 template_id 时返回 ("", true)，由调用方处理。
+func templateIDFromCwdConfig() (string, bool) {
+	cfg, err := config.LoadFromCwd()
+	if err != nil {
+		sbClient.PrintError("load config: %v", err)
+		return "", false
+	}
+	if cfg == nil || cfg.TemplateID == "" {
+		return "", true
+	}
+	fmt.Fprintf(os.Stderr, "[config] using template_id from %s\n", cfg.SourcePath())
+	return cfg.TemplateID, true
+}

--- a/iqshell/sandbox/template/operations/delete.go
+++ b/iqshell/sandbox/template/operations/delete.go
@@ -18,6 +18,20 @@ type DeleteInfo struct {
 
 // Delete deletes one or more templates.
 func Delete(info DeleteInfo) {
+	if len(info.TemplateIDs) == 0 && !info.Select {
+		id, ok := templateIDFromCwdConfig()
+		if !ok {
+			return
+		}
+		if id != "" {
+			info.TemplateIDs = []string{id}
+		}
+	}
+	if len(info.TemplateIDs) == 0 && !info.Select {
+		sbClient.PrintError("at least one template ID is required (positional args, --select, or qshell.sandbox.toml)")
+		return
+	}
+
 	client, err := sbClient.NewSandboxClient()
 	if err != nil {
 		sbClient.PrintError("%v", err)

--- a/iqshell/sandbox/template/operations/get.go
+++ b/iqshell/sandbox/template/operations/get.go
@@ -16,7 +16,14 @@ type GetInfo struct {
 // Get retrieves and displays template details.
 func Get(info GetInfo) {
 	if info.TemplateID == "" {
-		sbClient.PrintError("template ID is required")
+		id, ok := templateIDFromCwdConfig()
+		if !ok {
+			return
+		}
+		info.TemplateID = id
+	}
+	if info.TemplateID == "" {
+		sbClient.PrintError("template ID is required (positional arg or qshell.sandbox.toml)")
 		return
 	}
 

--- a/iqshell/sandbox/template/operations/publish.go
+++ b/iqshell/sandbox/template/operations/publish.go
@@ -20,6 +20,20 @@ type PublishInfo struct {
 
 // Publish publishes or unpublishes one or more templates.
 func Publish(info PublishInfo) {
+	if len(info.TemplateIDs) == 0 && !info.Select {
+		id, ok := templateIDFromCwdConfig()
+		if !ok {
+			return
+		}
+		if id != "" {
+			info.TemplateIDs = []string{id}
+		}
+	}
+	if len(info.TemplateIDs) == 0 && !info.Select {
+		sbClient.PrintError("at least one template ID is required (positional args, --select, or qshell.sandbox.toml)")
+		return
+	}
+
 	client, err := sbClient.NewSandboxClient()
 	if err != nil {
 		sbClient.PrintError("%v", err)


### PR DESCRIPTION
## Summary

为 `qshell sandbox template` 命令族新增 `qshell.sandbox.toml` 配置文件支持，解决重复使用 `--name` 触发 409 冲突的核心痛点，并让模板参数可以持久化、团队共享、CI 友好。

- 新增独立配置包 `iqshell/sandbox/template/config`（Load / FindInDir / LoadFromCwd / ApplyTo / WriteTemplateID）
- `build` 命令新增 `--config` 参数；无 `--config` 时在当前工作目录自动查找 `qshell.sandbox.toml`
- 首次构建成功后，qshell 自动把新模板的 `template_id` 回写到配置文件，后续重建幂等
- `get` / `delete` / `publish` / `unpublish` 在未传入 `template_id` 时自动从配置文件读取
- 字段优先级：CLI flag > 配置文件 > 内置默认值，CLI 覆盖会打印到 stderr
- 未放置配置文件时行为与现状完全一致（向后兼容）

## 主要变更

- `iqshell/sandbox/template/config/`（4 个新文件 + 9 个单元测试）
- `iqshell/sandbox/template/operations/build.go` 接入加载/合并/回写
- `iqshell/sandbox/template/operations/get.go|delete.go|publish.go` 加入配置回退
- `cmd/sandbox_template.go` 注册 `--config`，更新 Example/Long
- `docs/sandbox_template_config.md`（新增）、`docs/sandbox_template_build.md`（追加章节）、`docs/docs.go`（注册）
- `CHANGELOG.md` Unreleased 条目

## Test plan

- [x] 11 个单元测试全部通过：`go test -tags unit ./iqshell/sandbox/template/config/...`
- [x] 全量 `make test` 通过
- [x] `staticcheck ./iqshell/sandbox/template/... ./cmd/...` 无告警
- [x] `gofmt -s -l .` 无输出
- [x] `go build ./...` 通过
- [x] 本地端到端冒烟（需要沙箱凭证）
