### PR TITLE
fix(sandbox/template): rebuild 走 RebuildTemplate 申请新的 waiting build

### DIFF
--- a/cmd/sandbox_template.go
+++ b/cmd/sandbox_template.go
@@ -155,10 +155,13 @@ var templateBuildCmdBuilder = func(cfg *iqshell.Config) *cobra.Command {
 		Short:   "Build a template (alias: bd)",
 		Long: `Create a new template and build it, or rebuild an existing template.
 
-Supports three build modes:
+Creating a new template supports three build modes:
   1. --from-image: Build from a base Docker image
   2. --from-template: Build from an existing template
-  3. --dockerfile: Build from a Dockerfile (v2 build system)`,
+  3. --dockerfile: Build from a Dockerfile (v2 build system)
+
+Rebuilding an existing template (--template-id) requires --dockerfile
+because the rebuild API must carry the Dockerfile content in the request body.`,
 		Example: `  # Create and build a new template from a Docker image
   qshell sandbox template build --name my-template --from-image ubuntu:22.04 --wait
   qshell sbx tpl bd --name my-template --from-image ubuntu:22.04 --wait
@@ -171,13 +174,13 @@ Supports three build modes:
   qshell sandbox template build --name my-template --dockerfile ./Dockerfile --path ./context --wait
   qshell sbx tpl bd --name my-template --dockerfile ./Dockerfile --path ./context --wait
 
-  # Rebuild an existing template
-  qshell sandbox template build --template-id tmpl-xxxxxxxxxxxx --from-image ubuntu:22.04
-  qshell sbx tpl bd --template-id tmpl-xxxxxxxxxxxx --from-image ubuntu:22.04
+  # Rebuild an existing template (Dockerfile required)
+  qshell sandbox template build --template-id tmpl-xxxxxxxxxxxx --dockerfile ./Dockerfile --wait
+  qshell sbx tpl bd --template-id tmpl-xxxxxxxxxxxx --dockerfile ./Dockerfile --wait
 
   # Force rebuild without cache
-  qshell sandbox template build --template-id tmpl-xxxxxxxxxxxx --no-cache --wait
-  qshell sbx tpl bd --template-id tmpl-xxxxxxxxxxxx --no-cache --wait`,
+  qshell sandbox template build --template-id tmpl-xxxxxxxxxxxx --dockerfile ./Dockerfile --no-cache --wait
+  qshell sbx tpl bd --template-id tmpl-xxxxxxxxxxxx --dockerfile ./Dockerfile --no-cache --wait`,
 		Run: func(cmd *cobra.Command, args []string) {
 			cfg.CmdCfg.CmdId = docs.SandboxTemplateBuildType
 			if iqshell.ShowDocumentIfNeeded(cfg) {

--- a/docs/sandbox_template_build.md
+++ b/docs/sandbox_template_build.md
@@ -1,5 +1,11 @@
 # 简介
-`sandbox template build`（别名 `bd`）创建新模板并触发构建，或对已有模板重新构建。支持三种构建模式：`--from-image` 基于 Docker 镜像、`--from-template` 基于已有模板、`--dockerfile` 基于 Dockerfile（v2 构建系统）。支持 `--no-cache` 强制完整构建和 `--wait` 流式查看构建日志。
+`sandbox template build`（别名 `bd`）创建新模板并触发构建，或对已有模板重新构建。
+
+**创建新模板** 支持三种构建模式：`--from-image` 基于 Docker 镜像、`--from-template` 基于已有模板、`--dockerfile` 基于 Dockerfile（v2 构建系统）。
+
+**重新构建已有模板**（`--template-id`）必须提供 `--dockerfile`——服务端 rebuild 接口要求在请求体中携带 Dockerfile 内容。
+
+支持 `--no-cache` 强制完整构建和 `--wait` 流式查看构建日志。
 
 # 格式
 ```
@@ -18,7 +24,7 @@ $ qshell sandbox template build --doc
 
 # 参数
 - `--name`：模板名称（创建新模板时使用，与 --template-id 二选一）
-- `--template-id`：已有模板 ID（重新构建时使用，与 --name 二选一）
+- `--template-id`：已有模板 ID（重新构建时使用，与 --name 二选一，必须同时提供 `--dockerfile`）
 - `--from-image`：基础 Docker 镜像
 - `--from-template`：基础模板
 - `--dockerfile`：Dockerfile 路径（启用 v2 构建系统，自动解析 FROM/RUN/COPY 等指令）
@@ -48,19 +54,19 @@ $ qshell sbx tpl bd --name my-template --dockerfile ./Dockerfile --wait
 $ qshell sandbox template build --name my-template --dockerfile ./docker/Dockerfile --path ./src --wait
 ```
 
-4. 重新构建已有模板
+4. 重新构建已有模板（rebuild 必须提供 Dockerfile）
 ```
-$ qshell sandbox template build --template-id tmpl-xxxxxxxxxxxx --from-image ubuntu:22.04
+$ qshell sandbox template build --template-id tmpl-xxxxxxxxxxxx --dockerfile ./Dockerfile --wait
 ```
 
-5. 使用 Dockerfile 重新构建已有模板
+5. 使用 Dockerfile 重新构建已有模板（忽略缓存）
 ```
 $ qshell sandbox template build --template-id tmpl-xxxxxxxxxxxx --dockerfile ./Dockerfile --no-cache --wait
 ```
 
 6. 强制完整构建（忽略缓存）
 ```
-$ qshell sandbox template build --template-id tmpl-xxxxxxxxxxxx --no-cache --wait
+$ qshell sandbox template build --template-id tmpl-xxxxxxxxxxxx --dockerfile ./Dockerfile --no-cache --wait
 ```
 
 7. 指定启动命令和资源配置

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/fatih/color v1.18.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/muesli/termenv v0.16.0
-	github.com/qiniu/go-sdk/v7 v7.26.9
+	github.com/qiniu/go-sdk/v7 v7.26.10
 	github.com/schollz/progressbar/v3 v3.8.6
 	github.com/spf13/cast v1.3.1
 	github.com/spf13/cobra v1.1.3

--- a/go.sum
+++ b/go.sum
@@ -334,8 +334,8 @@ github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7z
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/qiniu/go-sdk/v7 v7.26.9 h1:is9th0m6RCq9LBq7Cuh7mmGUTfR2xb68SGO3xH7ZrA0=
-github.com/qiniu/go-sdk/v7 v7.26.9/go.mod h1:ri7fGwbio0pRDFr8EK5TUpx0DbnpIMJ2bMSDxGWfCbk=
+github.com/qiniu/go-sdk/v7 v7.26.10 h1:1c2c+grH7b8k5inIDKc95CI8+mAzB5YtfQ/dLOB2nNo=
+github.com/qiniu/go-sdk/v7 v7.26.10/go.mod h1:ri7fGwbio0pRDFr8EK5TUpx0DbnpIMJ2bMSDxGWfCbk=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=

--- a/iqshell/sandbox/template/operations/build.go
+++ b/iqshell/sandbox/template/operations/build.go
@@ -323,10 +323,12 @@ func buildFromDockerfile(ctx context.Context, client *sandbox.Client, templateID
 }
 
 // dockerfileForRebuild 返回 rebuild 请求所需的 Dockerfile 文本。
-// E2B v1 rebuild API 必须在请求体中携带 Dockerfile 内容。
+// E2B v1 rebuild API（POST /templates/{id}）强制要求在请求体中携带
+// Dockerfile 内容，因此 --template-id 场景必须同时提供 --dockerfile；
+// --from-image / --from-template 仅适用于新建模板。
 func dockerfileForRebuild(info BuildInfo) (string, error) {
 	if info.Dockerfile == "" {
-		return "", fmt.Errorf("rebuild requires --dockerfile to provide Dockerfile content")
+		return "", fmt.Errorf("--dockerfile is required when rebuilding an existing template (--template-id); --from-image and --from-template only apply to new templates")
 	}
 	content, err := os.ReadFile(info.Dockerfile)
 	if err != nil {

--- a/iqshell/sandbox/template/operations/build.go
+++ b/iqshell/sandbox/template/operations/build.go
@@ -94,19 +94,38 @@ func Build(info BuildInfo) {
 		buildID = resp.BuildID
 		sbClient.PrintSuccess("Template %s created (build ID: %s)", templateID, buildID)
 	} else {
-		// 获取已有模板以查找最新的 build ID
-		tmpl, gErr := client.GetTemplate(ctx, templateID, nil)
-		if gErr != nil {
-			sbClient.PrintError("get template failed: %v", gErr)
+		// 对已有模板申请新的 waiting build（对齐 E2B CLI 的 rebuild 流程）：
+		// RebuildTemplate → StartTemplateBuild → WaitForBuild。
+		// 直接复用历史 build ID 会导致 400 "build is not in waiting state"。
+		dockerfileContent, dErr := dockerfileForRebuild(info)
+		if dErr != nil {
+			sbClient.PrintError("%v", dErr)
 			return
 		}
-		if len(tmpl.Builds) > 0 {
-			// 使用最后一个 build（API 按时间升序返回，最新的在末尾）
-			buildID = tmpl.Builds[len(tmpl.Builds)-1].BuildID
-		} else {
-			sbClient.PrintError("no builds found for template, cannot rebuild")
+		rebuildParams := sandbox.RebuildTemplateParams{
+			Dockerfile: dockerfileContent,
+		}
+		if info.CPUCount > 0 {
+			rebuildParams.CPUCount = &info.CPUCount
+		}
+		if info.MemoryMB > 0 {
+			rebuildParams.MemoryMB = &info.MemoryMB
+		}
+		if info.StartCmd != "" {
+			rebuildParams.StartCmd = &info.StartCmd
+		}
+		if info.ReadyCmd != "" {
+			rebuildParams.ReadyCmd = &info.ReadyCmd
+		}
+
+		fmt.Printf("Requesting new build for template %s...\n", templateID)
+		resp, rErr := client.RebuildTemplate(ctx, templateID, rebuildParams)
+		if rErr != nil {
+			sbClient.PrintError("rebuild template failed: %v", rErr)
 			return
 		}
+		buildID = resp.BuildID
+		sbClient.PrintSuccess("New build requested (build ID: %s)", buildID)
 	}
 
 	if info.Dockerfile != "" {
@@ -301,6 +320,19 @@ func buildFromDockerfile(ctx context.Context, client *sandbox.Client, templateID
 	}
 
 	return nil
+}
+
+// dockerfileForRebuild 返回 rebuild 请求所需的 Dockerfile 文本。
+// E2B v1 rebuild API 必须在请求体中携带 Dockerfile 内容。
+func dockerfileForRebuild(info BuildInfo) (string, error) {
+	if info.Dockerfile == "" {
+		return "", fmt.Errorf("rebuild requires --dockerfile to provide Dockerfile content")
+	}
+	content, err := os.ReadFile(info.Dockerfile)
+	if err != nil {
+		return "", fmt.Errorf("read Dockerfile: %w", err)
+	}
+	return string(content), nil
 }
 
 // printSDKExamples prints SDK usage examples for the given template ID.


### PR DESCRIPTION
## Summary

- 修复 `qshell sandbox template build --template-id <id>` rebuild 场景下报 `400 "build is not in waiting state"` 的问题
- 升级 `github.com/qiniu/go-sdk/v7` 到 `v7.26.10`（新增 `RebuildTemplate` wrapper + `apiKeyEditor` 同时注入 `X-API-Key` 与 `Authorization: Bearer` 以兼容 rebuild 端点认证要求）
- rebuild 流程对齐 E2B CLI：`RebuildTemplate` → `StartTemplateBuild` → `WaitForBuild`

## Context

之前直接复用 `GetTemplate` 返回的最后一个 build ID 来调用 `StartTemplateBuild`，服务端会拒绝：历史 build 已经构建完成、不处于 waiting 状态。正确做法是先调用 `POST /templates/{id}` rebuild 端点让服务端分配一个新的 waiting build ID。

rebuild 端点服务端强制要求 `Authorization: Bearer`（不接受 `X-API-Key`），go-sdk v7.26.10 已为 APIKey 认证路径同时注入两个 header（参考 E2B js-sdk），兼容新旧端点。

## Changes

- `go.mod` / `go.sum`：go-sdk `v7.26.9` → `v7.26.10`
- `iqshell/sandbox/template/operations/build.go`：
  - 已有模板分支改为 `client.RebuildTemplate(ctx, templateID, params)`，从返回值拿新的 waiting build ID
  - 透传 CPUCount / MemoryMB / StartCmd / ReadyCmd
  - 抽离 `dockerfileForRebuild` 辅助读取 Dockerfile 内容（rebuild API 要求请求体携带 Dockerfile 文本）

## Test plan

- [x] `make test` 通过
- [x] `make test-sandbox-unit` 通过
- [x] E2E：在真实模板目录 `templates/claude2` 执行 `qshell sandbox template build --wait`
  - rebuild → StartTemplateBuild → 流式日志 → `Build finished, took 43s` / `Status: ready`
- [x] 验证 `Authorization: Bearer` 注入后不影响使用 `Credentials` 认证的接口（`ListInjectionRules` 等，go-sdk 侧已覆盖）

## Related

- go-sdk PR [#210](https://github.com/qiniu/go-sdk/pull/210)（RebuildTemplate wrapper）
- go-sdk PR [#211](https://github.com/qiniu/go-sdk/pull/211)（apiKeyEditor dual-header）
- go-sdk release [v7.26.10](https://github.com/qiniu/go-sdk/releases/tag/v7.26.10)