### PR TITLE
fix(sandbox): 修正命令帮助与参数校验

### DIFF
--- a/cmd/sandbox.go
+++ b/cmd/sandbox.go
@@ -27,7 +27,15 @@ var sandboxCmdBuilder = func(cfg *iqshell.Config) *cobra.Command {
 
   # Connect to a sandbox
   qshell sandbox connect sb-xxxxxxxxxxxx
-  qshell sbx cn sb-xxxxxxxxxxxx`,
+  qshell sbx cn sb-xxxxxxxxxxxx
+
+  # Execute a command in a sandbox
+  qshell sandbox exec sb-xxxxxxxxxxxx -- ls -la
+  qshell sbx ex sb-xxxxxxxxxxxx -- ls -la
+
+  # Pause and resume a sandbox
+  qshell sandbox pause sb-xxxxxxxxxxxx
+  qshell sandbox resume sb-xxxxxxxxxxxx`,
 		Run: func(cmd *cobra.Command, args []string) {
 			cfg.CmdCfg.CmdId = docs.SandboxType
 			docs.ShowCmdDocument(docs.SandboxType)
@@ -107,8 +115,11 @@ var sandboxCreateCmdBuilder = func(cfg *iqshell.Config) *cobra.Command {
   qshell sbx cr my-template --injection-rule rule-openai --injection-rule rule-http
 
   # Create with inline injections
-  qshell sandbox create my-template --inline-injection 'type=openai,api-key=sk-xxx' --inline-injection 'type=http,base-url=https://api.example.com,headers=Authorization=Bearer token;X-Env=prod'
-  qshell sbx cr my-template --inline-injection 'type=openai,api-key=sk-xxx'`,
+  qshell sandbox create my-template \
+    --inline-injection 'type=openai,api-key=sk-xxx' \
+    --inline-injection 'type=http,base-url=https://api.example.com,headers=Authorization=Bearer token,X-Env=prod'
+  qshell sbx cr my-template \
+    --inline-injection 'type=openai,api-key=sk-xxx'`,
 		Args: cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			cfg.CmdCfg.CmdId = docs.SandboxCreateType
@@ -357,6 +368,9 @@ var sandboxExecCmdBuilder = func(cfg *iqshell.Config) *cobra.Command {
   # Pipe stdin to a command
   echo "hello world" | qshell sbx ex sb-xxxxxxxxxxxx -- cat
   cat file.txt | qshell sbx ex sb-xxxxxxxxxxxx -- wc -l
+
+  # Run a shell pipeline inside the sandbox
+  qshell sandbox exec sb-xxxxxxxxxxxx -- sh -lc 'cat /etc/os-release | head -5'
 
   # Run in background (print PID and return)
   qshell sandbox exec sb-xxxxxxxxxxxx -b -- python server.py

--- a/cmd/sandbox.go
+++ b/cmd/sandbox.go
@@ -13,6 +13,7 @@ var sandboxCmdBuilder = func(cfg *iqshell.Config) *cobra.Command {
 		Use:     "sandbox",
 		Aliases: []string{"sbx"},
 		Short:   "Manage sandboxes (alias: sbx)",
+		Args:    cobra.NoArgs,
 		Example: `  # View sandbox subcommands
   qshell sandbox -h
   qshell sbx -h
@@ -138,7 +139,7 @@ var sandboxCreateCmdBuilder = func(cfg *iqshell.Config) *cobra.Command {
 	cmd.Flags().StringArrayVarP(&info.EnvVars, "env-var", "e", nil, "environment variables (KEY=VALUE, can be specified multiple times)")
 	cmd.Flags().BoolVar(&info.AutoPause, "auto-pause", false, "automatically pause sandbox when timeout expires (instead of killing)")
 	cmd.Flags().StringArrayVar(&info.InjectionRuleID, "injection-rule", nil, "injection rule IDs to apply when creating the sandbox (can be specified multiple times)")
-	cmd.Flags().StringArrayVar(&info.InlineInjection, "inline-injection", nil, "inline injection spec to apply when creating the sandbox (can be specified multiple times, format: type=<type>,api-key=<key>,base-url=<url>,headers=<k1=v1;k2=v2>)")
+	cmd.Flags().StringArrayVar(&info.InlineInjection, "inline-injection", nil, "inline injection spec to apply when creating the sandbox (can be specified multiple times, format: type=<type>,api-key=<key>,base-url=<url>,headers=<k1=v1,k2=v2>)")
 	return cmd
 }
 

--- a/cmd/sandbox.go
+++ b/cmd/sandbox.go
@@ -118,7 +118,7 @@ var sandboxCreateCmdBuilder = func(cfg *iqshell.Config) *cobra.Command {
   # Create with inline injections
   qshell sandbox create my-template \
     --inline-injection 'type=openai,api-key=sk-xxx' \
-    --inline-injection 'type=http,base-url=https://api.example.com,headers=Authorization=Bearer token,X-Env=prod'
+    --inline-injection 'type=http,base-url=https://api.example.com,headers=Authorization=Bearer token;X-Env=prod'
   qshell sbx cr my-template \
     --inline-injection 'type=openai,api-key=sk-xxx'`,
 		Args: cobra.MaximumNArgs(1),
@@ -139,7 +139,7 @@ var sandboxCreateCmdBuilder = func(cfg *iqshell.Config) *cobra.Command {
 	cmd.Flags().StringArrayVarP(&info.EnvVars, "env-var", "e", nil, "environment variables (KEY=VALUE, can be specified multiple times)")
 	cmd.Flags().BoolVar(&info.AutoPause, "auto-pause", false, "automatically pause sandbox when timeout expires (instead of killing)")
 	cmd.Flags().StringArrayVar(&info.InjectionRuleID, "injection-rule", nil, "injection rule IDs to apply when creating the sandbox (can be specified multiple times)")
-	cmd.Flags().StringArrayVar(&info.InlineInjection, "inline-injection", nil, "inline injection spec to apply when creating the sandbox (can be specified multiple times, format: type=<type>,api-key=<key>,base-url=<url>,headers=<k1=v1,k2=v2>)")
+	cmd.Flags().StringArrayVar(&info.InlineInjection, "inline-injection", nil, "inline injection spec to apply when creating the sandbox (can be specified multiple times, format: type=<type>,api-key=<key>,base-url=<url>,headers=<k1=v1;k2=v2>)")
 	return cmd
 }
 

--- a/cmd/sandbox_injection_rule.go
+++ b/cmd/sandbox_injection_rule.go
@@ -97,7 +97,12 @@ var injectionRuleCreateCmdBuilder = func(cfg *iqshell.Config) *cobra.Command {
   qshell sandbox injection-rule create --name anthropic-proxy --type anthropic --api-key sk-ant --base-url https://anthropic-proxy.example.com
 
   # Create a custom HTTP injection rule
-  qshell sandbox injection-rule create --name api-auth --type http --base-url https://api.example.com --headers "Authorization=Bearer token123,X-Env=prod"`,
+  qshell sandbox injection-rule create --name api-auth --type http --base-url https://api.example.com --headers "Authorization=Bearer token123,X-Env=prod"
+  qshell sbx ir cr --name api-auth --type http --base-url https://api.example.com --headers "Authorization=Bearer token123,X-Env=prod"
+
+  # Create a Qiniu AI API injection rule
+  qshell sandbox injection-rule create --name qiniu-ai --type qiniu --api-key ak-xxx
+  qshell sbx ir cr --name qiniu-ai --type qiniu --api-key ak-xxx`,
 		Run: func(cmd *cobra.Command, args []string) {
 			cfg.CmdCfg.CmdId = docs.SandboxInjectionRuleCreateType
 			if iqshell.ShowDocumentIfNeeded(cfg) {
@@ -129,9 +134,15 @@ var injectionRuleUpdateCmdBuilder = func(cfg *iqshell.Config) *cobra.Command {
 
   # Update to a Gemini injection with custom base URL
   qshell sandbox injection-rule update rule-xxxxxxxxxxxx --type gemini --api-key sk-gem --base-url https://gemini-proxy.example.com
+  qshell sbx ir up rule-xxxxxxxxxxxx --type gemini --api-key sk-gem --base-url https://gemini-proxy.example.com
 
   # Update custom HTTP headers
-  qshell sandbox injection-rule update rule-xxxxxxxxxxxx --type http --base-url https://api.example.com --headers "Authorization=Bearer newtoken"`,
+  qshell sandbox injection-rule update rule-xxxxxxxxxxxx --type http --base-url https://api.example.com --headers "Authorization=Bearer newtoken"
+  qshell sbx ir up rule-xxxxxxxxxxxx --type http --base-url https://api.example.com --headers "Authorization=Bearer newtoken"
+
+  # Update to a Qiniu AI API injection
+  qshell sandbox injection-rule update rule-xxxxxxxxxxxx --type qiniu --api-key ak-new
+  qshell sbx ir up rule-xxxxxxxxxxxx --type qiniu --api-key ak-new`,
 		Run: func(cmd *cobra.Command, args []string) {
 			cfg.CmdCfg.CmdId = docs.SandboxInjectionRuleUpdateType
 			if iqshell.ShowDocumentIfNeeded(cfg) {

--- a/cmd/sandbox_injection_rule.go
+++ b/cmd/sandbox_injection_rule.go
@@ -13,6 +13,7 @@ var injectionRuleCmdBuilder = func(cfg *iqshell.Config) *cobra.Command {
 		Use:     "injection-rule",
 		Aliases: []string{"ir"},
 		Short:   "Manage sandbox injection rules (alias: ir)",
+		Args:    cobra.NoArgs,
 		Example: `  # View injection-rule subcommands
   qshell sandbox injection-rule -h
   qshell sbx ir -h

--- a/cmd/sandbox_template.go
+++ b/cmd/sandbox_template.go
@@ -225,8 +225,8 @@ because the rebuild API must carry the Dockerfile content in the request body.
 	}
 	cmd.Flags().StringVar(&info.Name, "name", "", "template name (for creating a new template)")
 	cmd.Flags().StringVar(&info.TemplateID, "template-id", "", "existing template ID (for rebuilding)")
-	cmd.Flags().StringVar(&info.FromImage, "from-image", "", "base Docker image")
-	cmd.Flags().StringVar(&info.FromTemplate, "from-template", "", "base template")
+	cmd.Flags().StringVar(&info.FromImage, "from-image", "", "base Docker image (for creating a new template)")
+	cmd.Flags().StringVar(&info.FromTemplate, "from-template", "", "base template (for creating a new template)")
 	cmd.Flags().StringVar(&info.StartCmd, "start-cmd", "", "command to run after build")
 	cmd.Flags().StringVar(&info.ReadyCmd, "ready-cmd", "", "readiness check command")
 	cmd.Flags().Int32Var(&info.CPUCount, "cpu", 0, "sandbox CPU count")

--- a/cmd/sandbox_template.go
+++ b/cmd/sandbox_template.go
@@ -27,7 +27,11 @@ var templateCmdBuilder = func(cfg *iqshell.Config) *cobra.Command {
 
   # Get template details
   qshell sandbox template get tmpl-xxxxxxxxxxxx
-  qshell sbx tpl gt tmpl-xxxxxxxxxxxx`,
+  qshell sbx tpl gt tmpl-xxxxxxxxxxxx
+
+  # Build with qshell.sandbox.toml in the current directory
+  qshell sandbox template build --wait
+  qshell sbx tpl bd --wait`,
 		Run: func(cmd *cobra.Command, args []string) {
 			cfg.CmdCfg.CmdId = docs.SandboxTemplateType
 			docs.ShowCmdDocument(docs.SandboxTemplateType)
@@ -68,7 +72,11 @@ var templateGetCmdBuilder = func(cfg *iqshell.Config) *cobra.Command {
 		Short:   "Get template details (alias: gt)",
 		Example: `  # Get template details
   qshell sandbox template get tmpl-xxxxxxxxxxxx
-  qshell sbx tpl gt tmpl-xxxxxxxxxxxx`,
+  qshell sbx tpl gt tmpl-xxxxxxxxxxxx
+
+  # Get template details from qshell.sandbox.toml in the current directory
+  qshell sandbox template get
+  qshell sbx tpl gt`,
 		Run: func(cmd *cobra.Command, args []string) {
 			cfg.CmdCfg.CmdId = docs.SandboxTemplateGetType
 			if iqshell.ShowDocumentIfNeeded(cfg) {
@@ -106,7 +114,11 @@ var templateDeleteCmdBuilder = func(cfg *iqshell.Config) *cobra.Command {
 
   # Interactively select templates to delete
   qshell sandbox template delete -s
-  qshell sbx tpl dl -s`,
+  qshell sbx tpl dl -s
+
+  # Delete the template recorded in qshell.sandbox.toml
+  qshell sandbox template delete -y
+  qshell sbx tpl dl -y`,
 		Run: func(cmd *cobra.Command, args []string) {
 			cfg.CmdCfg.CmdId = docs.SandboxTemplateDeleteType
 			if iqshell.ShowDocumentIfNeeded(cfg) {
@@ -196,9 +208,11 @@ because the rebuild API must carry the Dockerfile content in the request body.
 
   # 使用 qshell.sandbox.toml（当前目录）
   qshell sandbox template build --wait
+  qshell sbx tpl bd --wait
 
   # 显式指定配置文件
-  qshell sandbox template build --config ./configs/prod.toml --wait`,
+  qshell sandbox template build --config ./configs/prod.toml --wait
+  qshell sbx tpl bd --config ./configs/prod.toml --wait`,
 		Run: func(cmd *cobra.Command, args []string) {
 			cfg.CmdCfg.CmdId = docs.SandboxTemplateBuildType
 			if iqshell.ShowDocumentIfNeeded(cfg) {
@@ -236,7 +250,11 @@ var templatePublishCmdBuilder = func(cfg *iqshell.Config) *cobra.Command {
 
   # Interactively select templates to publish
   qshell sandbox template publish -s
-  qshell sbx tpl pb -s`,
+  qshell sbx tpl pb -s
+
+  # Publish the template recorded in qshell.sandbox.toml
+  qshell sandbox template publish -y
+  qshell sbx tpl pb -y`,
 		Run: func(cmd *cobra.Command, args []string) {
 			cfg.CmdCfg.CmdId = docs.SandboxTemplatePublishType
 			if iqshell.ShowDocumentIfNeeded(cfg) {
@@ -263,7 +281,11 @@ var templateUnpublishCmdBuilder = func(cfg *iqshell.Config) *cobra.Command {
 
   # Interactively select templates to unpublish
   qshell sandbox template unpublish -s
-  qshell sbx tpl upb -s`,
+  qshell sbx tpl upb -s
+
+  # Unpublish the template recorded in qshell.sandbox.toml
+  qshell sandbox template unpublish -y
+  qshell sbx tpl upb -y`,
 		Run: func(cmd *cobra.Command, args []string) {
 			cfg.CmdCfg.CmdId = docs.SandboxTemplateUnpublishType
 			if iqshell.ShowDocumentIfNeeded(cfg) {

--- a/cmd/sandbox_template.go
+++ b/cmd/sandbox_template.go
@@ -71,6 +71,7 @@ var templateGetCmdBuilder = func(cfg *iqshell.Config) *cobra.Command {
 		Use:     "get [templateID]",
 		Aliases: []string{"gt"},
 		Short:   "Get template details (alias: gt)",
+		Args:    cobra.MaximumNArgs(1),
 		Example: `  # Get template details
   qshell sandbox template get tmpl-xxxxxxxxxxxx
   qshell sbx tpl gt tmpl-xxxxxxxxxxxx
@@ -81,10 +82,6 @@ var templateGetCmdBuilder = func(cfg *iqshell.Config) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			cfg.CmdCfg.CmdId = docs.SandboxTemplateGetType
 			if iqshell.ShowDocumentIfNeeded(cfg) {
-				return
-			}
-			if len(args) > 1 {
-				_ = cmd.Usage()
 				return
 			}
 			id := ""

--- a/cmd/sandbox_template.go
+++ b/cmd/sandbox_template.go
@@ -13,6 +13,7 @@ var templateCmdBuilder = func(cfg *iqshell.Config) *cobra.Command {
 		Use:     "template",
 		Aliases: []string{"tpl"},
 		Short:   "Manage sandbox templates (alias: tpl)",
+		Args:    cobra.NoArgs,
 		Example: `  # View template subcommands
   qshell sandbox template -h
   qshell sbx tpl -h
@@ -67,7 +68,7 @@ var templateListCmdBuilder = func(cfg *iqshell.Config) *cobra.Command {
 
 var templateGetCmdBuilder = func(cfg *iqshell.Config) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "get <templateID>",
+		Use:     "get [templateID]",
 		Aliases: []string{"gt"},
 		Short:   "Get template details (alias: gt)",
 		Example: `  # Get template details
@@ -332,6 +333,27 @@ var templateInitCmdBuilder = func(cfg *iqshell.Config) *cobra.Command {
 	return cmd
 }
 
+var templateConfigCmdBuilder = func(cfg *iqshell.Config) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "config",
+		Aliases: []string{"cfg"},
+		Short:   "Show qshell.sandbox.toml configuration reference (alias: cfg)",
+		Args:    cobra.NoArgs,
+		Example: `  # Show qshell.sandbox.toml configuration reference
+  qshell sandbox template config
+  qshell sbx tpl cfg
+
+  # Show detailed documentation
+  qshell sandbox template config --doc
+  qshell sbx tpl cfg --doc`,
+		Run: func(cmd *cobra.Command, args []string) {
+			cfg.CmdCfg.CmdId = docs.SandboxTemplateConfigType
+			docs.ShowCmdDocument(docs.SandboxTemplateConfigType)
+		},
+	}
+	return cmd
+}
+
 // templateCmdLoader adds the template command and its subcommands to the given parent command.
 func templateCmdLoader(parentCmd *cobra.Command, cfg *iqshell.Config) {
 	templateCmd := templateCmdBuilder(cfg)
@@ -344,6 +366,7 @@ func templateCmdLoader(parentCmd *cobra.Command, cfg *iqshell.Config) {
 		templatePublishCmdBuilder(cfg),
 		templateUnpublishCmdBuilder(cfg),
 		templateInitCmdBuilder(cfg),
+		templateConfigCmdBuilder(cfg),
 	)
 	parentCmd.AddCommand(templateCmd)
 }

--- a/cmd_test/sandbox_template_test.go
+++ b/cmd_test/sandbox_template_test.go
@@ -3,6 +3,7 @@
 package cmd
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/qiniu/qshell/v2/cmd_test/test"
@@ -44,6 +45,10 @@ func TestSandboxTemplateUnpublishDocument(t *testing.T) {
 
 func TestSandboxTemplateInitDocument(t *testing.T) {
 	testSubcommandDocument(t, "sandbox", "template", "init")
+}
+
+func TestSandboxTemplateConfigDocument(t *testing.T) {
+	testSubcommandDocument(t, "sandbox", "template", "config")
 }
 
 // === sandbox template missing args tests ===
@@ -112,4 +117,11 @@ func TestSandboxTemplateBuildDocumentWithDockerfileAndPath(t *testing.T) {
 
 func TestSandboxTemplateInitDocumentWithFlags(t *testing.T) {
 	testSubcommandDocumentWithFlags(t, []string{"sandbox", "template", "init"}, "--name", "test")
+}
+
+func TestSandboxTemplateConfigDocumentWithAlias(t *testing.T) {
+	result, _ := test.RunCmdWithError("sbx", "tpl", "cfg", test.DocumentOption)
+	if !strings.Contains(result, "`sandbox template config`") {
+		t.Fatalf("document test fail for sbx tpl cfg, got prefix: %.80s", result)
+	}
 }

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -1,5 +1,5 @@
 # 简介
-`sandbox`（别名 `sbx`）命令用于管理沙箱实例和模板，支持创建、连接、终止沙箱以及查看沙箱日志和指标。
+`sandbox`（别名 `sbx`）命令用于管理沙箱实例、模板和注入规则，支持创建、连接、执行命令、暂停、恢复、终止沙箱，以及查看沙箱日志和指标。
 
 # 格式
 ```
@@ -28,12 +28,15 @@ $ qshell sandbox --doc
 sandbox 的子命令有：
 * list（ls）：列出沙箱
 * create（cr）：创建沙箱并连接终端
-* injection-rule（ir）：管理沙箱注入规则
 * connect（cn）：连接到已有沙箱终端
 * kill（kl）：终止沙箱
+* pause（ps）：暂停沙箱
+* resume（rs）：恢复已暂停的沙箱
+* exec（ex）：在沙箱中执行命令
 * logs（lg）：查看沙箱日志
 * metrics（mt）：查看沙箱资源指标
 * template（tpl）：管理沙箱模板
+* injection-rule（ir）：管理沙箱注入规则
 
 # 示例
 1. 列出所有运行中的沙箱
@@ -56,8 +59,9 @@ qshell sbx cr my-template --injection-rule rule-openai --injection-rule rule-htt
 
 4. 创建沙箱时附加内联注入配置
 ```
-qshell sandbox create my-template --inline-injection 'type=openai,api-key=sk-xxx'
-qshell sbx cr my-template --inline-injection 'type=http,base-url=https://api.example.com,headers=Authorization=Bearer token,X-Env=prod'
+qshell sandbox create my-template \
+  --inline-injection 'type=openai,api-key=sk-xxx' \
+  --inline-injection 'type=http,base-url=https://api.example.com,headers=Authorization=Bearer token,X-Env=prod'
 ```
 
 5. 管理注入规则
@@ -72,7 +76,19 @@ qshell sandbox connect sb-xxxxxxxxxxxx
 qshell sbx cn sb-xxxxxxxxxxxx
 ```
 
-7. 终止沙箱
+7. 在沙箱中执行命令
+```
+qshell sandbox exec sb-xxxxxxxxxxxx -- ls -la
+qshell sbx ex sb-xxxxxxxxxxxx -- ls -la
+```
+
+8. 暂停并恢复沙箱
+```
+qshell sandbox pause sb-xxxxxxxxxxxx
+qshell sandbox resume sb-xxxxxxxxxxxx
+```
+
+9. 终止沙箱
 ```
 qshell sandbox kill sb-xxxxxxxxxxxx
 qshell sbx kl sb-xxxxxxxxxxxx

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -61,7 +61,7 @@ qshell sbx cr my-template --injection-rule rule-openai --injection-rule rule-htt
 ```
 qshell sandbox create my-template \
   --inline-injection 'type=openai,api-key=sk-xxx' \
-  --inline-injection 'type=http,base-url=https://api.example.com,headers=Authorization=Bearer token,X-Env=prod'
+  --inline-injection 'type=http,base-url=https://api.example.com,headers=Authorization=Bearer token;X-Env=prod'
 ```
 
 5. 管理注入规则

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -67,7 +67,7 @@ qshell sandbox create my-template \
 5. 管理注入规则
 ```
 qshell sandbox injection-rule list
-qshell sbx ir create --name openai-default --type openai --api-key sk-xxx
+qshell sbx ir cr --name openai-default --type openai --api-key sk-xxx
 ```
 
 6. 连接到沙箱

--- a/docs/sandbox_create.md
+++ b/docs/sandbox_create.md
@@ -1,5 +1,5 @@
 # 简介
-`sandbox create`（别名 `cr`）创建一个新的沙箱实例并连接到其终端。当终端会话结束时，沙箱将被自动终止。
+`sandbox create`（别名 `cr`）从指定模板创建一个新的沙箱实例并连接到其终端。当终端会话结束时，沙箱将被自动终止。
 
 使用 `--detach` 模式时，创建沙箱后不连接终端，沙箱保持存活直到超时。
 
@@ -7,8 +7,8 @@
 
 # 格式
 ```
-qshell sandbox create <template> [-t <seconds>] [-d] [-m <metadata>] [--injection-rule <ruleID>...] [--inline-injection <spec>...]
-qshell sbx cr <template> [-t <seconds>] [-d] [-m <metadata>] [--injection-rule <ruleID>...] [--inline-injection <spec>...]
+qshell sandbox create [template] [-t <seconds>] [--detach] [-m <metadata>] [-e <KEY=VALUE>...] [--auto-pause] [--injection-rule <ruleID>...] [--inline-injection <spec>...]
+qshell sbx cr [template] [-t <seconds>] [--detach] [-m <metadata>] [-e <KEY=VALUE>...] [--auto-pause] [--injection-rule <ruleID>...] [--inline-injection <spec>...]
 ```
 
 # 帮助文档
@@ -21,10 +21,12 @@ $ qshell sandbox create --doc
 需要配置 `QINIU_API_KEY` 或 `E2B_API_KEY` 环境变量，或在当前目录 `.env` 文件中设置。
 
 # 参数
-- `template`：模板 ID（必填）
+- `template`：模板 ID（实际创建时必填；命令参数层最多接受 1 个模板参数）
 - `-t, --timeout`：沙箱超时时间（秒）
-- `-d, --detach`：创建沙箱但不连接终端，沙箱保持存活直到超时
+- `--detach`：创建沙箱但不连接终端，沙箱保持存活直到超时。此参数没有短参数
 - `-m, --metadata`：元数据键值对（格式：key1=value1,key2=value2）
+- `-e, --env-var`：环境变量（KEY=VALUE 格式，可多次指定）
+- `--auto-pause`：超时后自动暂停沙箱，而不是终止沙箱
 - `--injection-rule`：创建沙箱时附加的注入规则 ID，可多次指定
 - `--inline-injection`：创建沙箱时附加的内联注入配置，可多次指定，格式为 `type=<type>,api-key=<key>,base-url=<url>,headers=<k1=v1,k2=v2>`
 
@@ -50,24 +52,38 @@ $ qshell sbx cr my-template -t 300
 
 3. 分离模式创建（不连接终端，沙箱存活 5 分钟）
 ```
-$ qshell sandbox create my-template -t 300 -d
-$ qshell sbx cr my-template -t 300 -d
+$ qshell sandbox create my-template -t 300 --detach
+$ qshell sbx cr my-template -t 300 --detach
 ```
 
-4. 添加元数据
+4. 设置环境变量
+```
+$ qshell sandbox create my-template -e FOO=bar -e BAZ=qux
+$ qshell sbx cr my-template -e FOO=bar -e BAZ=qux
+```
+
+5. 超时后自动暂停
+```
+$ qshell sandbox create my-template -t 300 --auto-pause
+$ qshell sbx cr my-template -t 300 --auto-pause
+```
+
+6. 添加元数据
 ```
 $ qshell sandbox create my-template -m env=dev,team=backend
 $ qshell sbx cr my-template -m env=dev,team=backend
 ```
 
-5. 创建时附加注入规则
+7. 创建时附加注入规则
 ```
 $ qshell sandbox create my-template --injection-rule rule-openai --injection-rule rule-http
 $ qshell sbx cr my-template --injection-rule rule-openai --injection-rule rule-http
 ```
 
-6. 创建时附加内联注入配置
+8. 创建时附加内联注入配置
 ```
-$ qshell sandbox create my-template --inline-injection 'type=openai,api-key=sk-xxx' --inline-injection 'type=http,base-url=https://api.example.com,headers=Authorization=Bearer token,X-Env=prod'
+$ qshell sandbox create my-template \
+    --inline-injection 'type=openai,api-key=sk-xxx' \
+    --inline-injection 'type=http,base-url=https://api.example.com,headers=Authorization=Bearer token,X-Env=prod'
 $ qshell sbx cr my-template --inline-injection 'type=gemini,api-key=sk-gem'
 ```

--- a/docs/sandbox_create.md
+++ b/docs/sandbox_create.md
@@ -28,14 +28,13 @@ $ qshell sandbox create --doc
 - `-e, --env-var`：环境变量（KEY=VALUE 格式，可多次指定）
 - `--auto-pause`：超时后自动暂停沙箱，而不是终止沙箱
 - `--injection-rule`：创建沙箱时附加的注入规则 ID，可多次指定
-- `--inline-injection`：创建沙箱时附加的内联注入配置，可多次指定，格式为 `type=<type>,api-key=<key>,base-url=<url>,headers=<k1=v1,k2=v2>`
+- `--inline-injection`：创建沙箱时附加的内联注入配置，可多次指定，格式为 `type=<type>,api-key=<key>,base-url=<url>,headers=<k1=v1;k2=v2>`
 
 内联注入说明：
 - `type` 支持 `openai`、`anthropic`、`gemini`、`qiniu`、`http`
 - `api-key` 可用于 `openai`、`anthropic`、`gemini`、`qiniu`
 - `base-url` 可用于覆盖默认目标地址；`type=http` 时必填，`type=qiniu` 默认目标地址为 `api.qnaigc.com`
-- `headers` 仅用于 `type=http`，多个请求头使用逗号分隔，例如 `headers=Authorization=Bearer token,X-Env=prod`
-- `headers` 建议放在内联配置的最后一个字段，避免和其他顶层字段分隔符冲突
+- `headers` 仅用于 `type=http`，多个请求头使用分号分隔，例如 `headers=Authorization=Bearer token;X-Env=prod`
 
 # 示例
 1. 创建沙箱
@@ -84,6 +83,6 @@ $ qshell sbx cr my-template --injection-rule rule-openai --injection-rule rule-h
 ```
 $ qshell sandbox create my-template \
     --inline-injection 'type=openai,api-key=sk-xxx' \
-    --inline-injection 'type=http,base-url=https://api.example.com,headers=Authorization=Bearer token,X-Env=prod'
+    --inline-injection 'type=http,base-url=https://api.example.com,headers=Authorization=Bearer token;X-Env=prod'
 $ qshell sbx cr my-template --inline-injection 'type=gemini,api-key=sk-gem'
 ```

--- a/docs/sandbox_exec.md
+++ b/docs/sandbox_exec.md
@@ -33,21 +33,27 @@ $ qshell sbx ex sb-xxxxxxxxxxxx -- ls -la
 
 2. 执行带管道的复杂命令
 ```
-$ qshell sandbox exec sb-xxxxxxxxxxxx -- cat /etc/os-release | head -5
+$ qshell sandbox exec sb-xxxxxxxxxxxx -- sh -lc 'cat /etc/os-release | head -5'
 ```
 
-3. 后台运行命令
+3. 将本地标准输入传给沙箱命令
+```
+$ echo "hello world" | qshell sbx ex sb-xxxxxxxxxxxx -- cat
+$ cat file.txt | qshell sbx ex sb-xxxxxxxxxxxx -- wc -l
+```
+
+4. 后台运行命令
 ```
 $ qshell sandbox exec sb-xxxxxxxxxxxx -b -- python server.py
 $ qshell sbx ex sb-xxxxxxxxxxxx -b -- python server.py
 ```
 
-4. 指定工作目录和用户
+5. 指定工作目录和用户
 ```
 $ qshell sandbox exec sb-xxxxxxxxxxxx -c /app -u root -- npm install
 ```
 
-5. 设置环境变量
+6. 设置环境变量
 ```
 $ qshell sandbox exec sb-xxxxxxxxxxxx -e PORT=3000 -e NODE_ENV=production -- node app.js
 ```

--- a/docs/sandbox_injection_rule.md
+++ b/docs/sandbox_injection_rule.md
@@ -1,29 +1,31 @@
+# 简介
 `sandbox injection-rule`（别名 `ir`）命令用于管理沙箱注入规则，支持列出、查看、创建、更新和删除注入规则。
 
-## 命令格式
+# 格式
 
 ```bash
 qshell sandbox injection-rule <子命令>
+qshell sbx ir <子命令>
 ```
 
-## 查看帮助
+# 帮助文档
 
 ```bash
 $ qshell sandbox injection-rule -h
 $ qshell sandbox injection-rule --doc
 ```
 
-## 子命令
+# 子命令
 
 `injection-rule` 的子命令有：
 
-- `list`：列出所有注入规则
-- `get`：查看指定注入规则详情
-- `create`：创建新的注入规则
-- `update`：更新已有注入规则
-- `delete`：删除一个或多个注入规则
+- `list`（`ls`）：列出所有注入规则
+- `get`（`gt`）：查看指定注入规则详情
+- `create`（`cr`）：创建新的注入规则
+- `update`（`up`）：更新已有注入规则
+- `delete`（`dl`）：删除一个或多个注入规则
 
-## 使用示例
+# 示例
 
 列出所有注入规则：
 

--- a/docs/sandbox_injection_rule_create.md
+++ b/docs/sandbox_injection_rule_create.md
@@ -1,27 +1,29 @@
+# 简介
 `sandbox injection-rule create`（别名 `cr`）创建一个新的注入规则。
 
-## 命令格式
+# 格式
 
 ```bash
 qshell sandbox injection-rule create --name <name> --type <openai|anthropic|gemini|qiniu|http> [--api-key <apiKey>] [--base-url <baseURL>] [--headers <headers>]
+qshell sbx ir cr --name <name> --type <openai|anthropic|gemini|qiniu|http> [--api-key <apiKey>] [--base-url <baseURL>] [--headers <headers>]
 ```
 
-## 查看帮助
+# 帮助文档
 
 ```bash
 $ qshell sandbox injection-rule create -h
 $ qshell sandbox injection-rule create --doc
 ```
 
-## 参数说明
+# 参数
 
 - `--name`：规则名称，必填，同一用户下唯一
 - `--type`：注入类型，必填，支持 `openai`、`anthropic`、`gemini`、`qiniu`、`http`
-- `--api-key`：`openai`、`anthropic`、`gemini`、`qiniu` 类型使用的 API Key
+- `--api-key`：`openai`、`anthropic`、`gemini`、`qiniu` 类型使用的 API Key。注意：通过 CLI 传递密钥可能泄露到 Shell 历史或进程列表
 - `--base-url`：覆盖默认目标地址，或 `http` 类型的目标基础 URL；`qiniu` 默认为 `api.qnaigc.com`
 - `--headers`：`http` 类型的请求头，使用逗号分隔的 `key=value` 形式
 
-## 使用示例
+# 示例
 
 创建 OpenAI 注入规则：
 

--- a/docs/sandbox_injection_rule_delete.md
+++ b/docs/sandbox_injection_rule_delete.md
@@ -1,25 +1,27 @@
+# 简介
 `sandbox injection-rule delete`（别名 `dl`）删除一个或多个注入规则。支持变参和交互式多选。
 
-## 命令格式
+# 格式
 
 ```bash
 qshell sandbox injection-rule delete [ruleIDs...] [-y] [-s]
+qshell sbx ir dl [ruleIDs...] [-y] [-s]
 ```
 
-## 查看帮助
+# 帮助文档
 
 ```bash
 $ qshell sandbox injection-rule delete -h
 $ qshell sandbox injection-rule delete --doc
 ```
 
-## 参数说明
+# 参数
 
 - `ruleIDs...`：一个或多个注入规则 ID
 - `-y, --yes`：跳过确认
 - `-s, --select`：交互式选择规则进行删除
 
-## 使用示例
+# 示例
 
 删除单个规则：
 

--- a/docs/sandbox_injection_rule_get.md
+++ b/docs/sandbox_injection_rule_get.md
@@ -1,23 +1,25 @@
+# 简介
 `sandbox injection-rule get`（别名 `gt`）查看注入规则的详细信息。
 
-## 命令格式
+# 格式
 
 ```bash
 qshell sandbox injection-rule get <ruleID>
+qshell sbx ir gt <ruleID>
 ```
 
-## 查看帮助
+# 帮助文档
 
 ```bash
 $ qshell sandbox injection-rule get -h
 $ qshell sandbox injection-rule get --doc
 ```
 
-## 参数说明
+# 参数
 
 - `ruleID`：注入规则 ID
 
-## 使用示例
+# 示例
 
 ```bash
 $ qshell sandbox injection-rule get rule-xxxxxxxxxxxx

--- a/docs/sandbox_injection_rule_list.md
+++ b/docs/sandbox_injection_rule_list.md
@@ -1,23 +1,25 @@
+# 简介
 `sandbox injection-rule list`（别名 `ls`）列出所有注入规则。
 
-## 命令格式
+# 格式
 
 ```bash
 qshell sandbox injection-rule list [--format <pretty|json>]
+qshell sbx ir ls [--format <pretty|json>]
 ```
 
-## 查看帮助
+# 帮助文档
 
 ```bash
 $ qshell sandbox injection-rule list -h
 $ qshell sandbox injection-rule list --doc
 ```
 
-## 参数说明
+# 参数
 
 - `--format`：输出格式，支持 `pretty` 和 `json`，默认 `pretty`
 
-## 使用示例
+# 示例
 
 默认表格输出：
 

--- a/docs/sandbox_injection_rule_update.md
+++ b/docs/sandbox_injection_rule_update.md
@@ -1,30 +1,32 @@
+# 简介
 `sandbox injection-rule update`（别名 `up`）更新指定的注入规则。
 
-## 命令格式
+# 格式
 
 ```bash
 qshell sandbox injection-rule update <ruleID> [--name <name>] [--type <openai|anthropic|gemini|qiniu|http>] [--api-key <apiKey>] [--base-url <baseURL>] [--headers <headers>]
+qshell sbx ir up <ruleID> [--name <name>] [--type <openai|anthropic|gemini|qiniu|http>] [--api-key <apiKey>] [--base-url <baseURL>] [--headers <headers>]
 ```
 
-## 查看帮助
+# 帮助文档
 
 ```bash
 $ qshell sandbox injection-rule update -h
 $ qshell sandbox injection-rule update --doc
 ```
 
-## 参数说明
+# 参数
 
 - `ruleID`：注入规则 ID
 - `--name`：新的规则名称
 - `--type`：新的注入类型；当需要更新注入配置时必须指定
-- `--api-key`：新的 API Key；更新注入配置时必须与 `--type` 一同指定
+- `--api-key`：新的 API Key；更新注入配置时必须与 `--type` 一同指定。注意：通过 CLI 传递密钥可能泄露到 Shell 历史或进程列表
 - `--base-url`：新的基础 URL；更新注入配置时必须与 `--type` 一同指定
 - `--headers`：新的自定义 HTTP 请求头，使用逗号分隔的 `key=value` 形式；更新时必须与 `--type http` 一同指定
 
 说明：如果只传 `--api-key`、`--base-url` 或 `--headers` 而不传 `--type`，命令会报错，因为当前实现无法从已有规则自动推断要更新的注入类型。
 
-## 使用示例
+# 示例
 
 更新规则名称：
 

--- a/docs/sandbox_template.md
+++ b/docs/sandbox_template.md
@@ -25,7 +25,7 @@ template 的子命令有：
 * list（ls）：列出模板
 * get（gt）：查看模板详情
 * delete（dl）：删除模板
-* build（bd）：创建并构建模板，支持 `qshell.sandbox.toml` 配置文件
+* build（bd）：创建并构建模板，或重新构建已有模板，支持 `qshell.sandbox.toml` 配置文件
 * builds（bds）：查看模板构建状态
 * publish（pb）：发布模板（设为公开）
 * unpublish（upb）：取消发布模板（设为私有）

--- a/docs/sandbox_template.md
+++ b/docs/sandbox_template.md
@@ -30,6 +30,7 @@ template 的子命令有：
 * publish（pb）：发布模板（设为公开）
 * unpublish（upb）：取消发布模板（设为私有）
 * init（it）：初始化模板项目脚手架
+* config（cfg）：查看 `qshell.sandbox.toml` 配置文件说明
 
 # 示例
 1. 列出所有模板
@@ -84,4 +85,10 @@ qshell sandbox template unpublish tmpl-xxxxxxxxxxxx -y
 ```
 qshell sandbox template init
 qshell sandbox template init --name my-template --language go
+```
+
+10. 查看配置文件说明
+```
+qshell sandbox template config
+qshell sbx tpl cfg
 ```

--- a/docs/sandbox_template_build.md
+++ b/docs/sandbox_template_build.md
@@ -7,12 +7,12 @@
 
 **重新构建已有模板**（`--template-id`）必须提供 `--dockerfile`——服务端 rebuild 接口要求在请求体中携带 Dockerfile 内容。
 
-支持 `--no-cache` 强制完整构建和 `--wait` 流式查看构建日志。
+支持 `qshell.sandbox.toml` 配置文件、`--config` 显式指定配置文件、`--no-cache` 强制完整构建和 `--wait` 流式查看构建日志。
 
 # 格式
 ```
-qshell sandbox template build [--name <name>] [--template-id <id>] [--from-image <image>] [--from-template <template>] [--dockerfile <path>] [--path <dir>] [--start-cmd <cmd>] [--ready-cmd <cmd>] [--cpu <N>] [--memory <N>] [--wait] [--no-cache]
-qshell sbx tpl bd [--name <name>] [--template-id <id>] [--from-image <image>] [--from-template <template>] [--dockerfile <path>] [--path <dir>] [--start-cmd <cmd>] [--ready-cmd <cmd>] [--cpu <N>] [--memory <N>] [--wait] [--no-cache]
+qshell sandbox template build [--name <name>] [--template-id <id>] [--from-image <image>] [--from-template <template>] [--dockerfile <path>] [--path <dir>] [--start-cmd <cmd>] [--ready-cmd <cmd>] [--cpu <N>] [--memory <N>] [--wait] [--no-cache] [--config <path>]
+qshell sbx tpl bd [--name <name>] [--template-id <id>] [--from-image <image>] [--from-template <template>] [--dockerfile <path>] [--path <dir>] [--start-cmd <cmd>] [--ready-cmd <cmd>] [--cpu <N>] [--memory <N>] [--wait] [--no-cache] [--config <path>]
 ```
 
 # 帮助文档
@@ -37,6 +37,12 @@ $ qshell sandbox template build --doc
 - `--memory`：沙箱内存大小（MiB）
 - `--wait`：等待构建完成，实时流式显示构建日志（带彩色级别标签）
 - `--no-cache`：强制完整构建，忽略缓存
+- `--config`：显式指定 `qshell.sandbox.toml` 配置文件路径；未指定时，如果当前目录存在 `qshell.sandbox.toml`，命令会自动读取
+
+# 配置文件
+`sandbox template build` 会按 `CLI flag > 配置文件 > 内置默认值` 合并参数。配置文件可提供 `template_id`、`name`、`dockerfile`、`path`、`from_image`、`from_template`、`start_cmd`、`ready_cmd`、`cpu_count`、`memory_mb` 和 `no_cache`。
+
+首次构建成功且配置文件存在、`template_id` 为空时，命令会自动把新模板 ID 回写到配置文件。更多字段说明见 `docs/sandbox_template_config.md`。
 
 # 示例
 1. 从 Docker 镜像创建并构建模板
@@ -78,21 +84,19 @@ $ qshell sandbox template build --template-id tmpl-xxxxxxxxxxxx --dockerfile ./D
 $ qshell sandbox template build --template-id tmpl-xxxxxxxxxxxx --dockerfile ./Dockerfile --no-cache --wait
 ```
 
-8. 指定启动命令和资源配置
+8. 使用当前目录的 `qshell.sandbox.toml`
+```
+$ qshell sandbox template build --wait
+$ qshell sbx tpl bd --wait
+```
+
+9. 显式指定配置文件
+```
+$ qshell sandbox template build --config ./configs/prod.toml --wait
+$ qshell sbx tpl bd --config ./configs/prod.toml --wait
+```
+
+10. 指定启动命令和资源配置
 ```
 $ qshell sandbox template build --name my-app --from-image node:18 --start-cmd "npm start" --cpu 2 --memory 1024 --wait
-```
-
-## 配置文件支持
-
-`build` 命令支持从 `qshell.sandbox.toml` 读取参数。详见
-[qshell.sandbox.toml 文档](./sandbox_template_config.md)。
-
-示例：
-```bash
-# 当前目录有 qshell.sandbox.toml
-qshell sandbox template build --wait
-
-# 显式指定路径
-qshell sandbox template build --config ./configs/prod.toml --wait
 ```

--- a/docs/sandbox_template_build.md
+++ b/docs/sandbox_template_build.md
@@ -27,8 +27,8 @@ $ qshell sandbox template build --doc
 # 参数
 - `--name`：模板名称（创建新模板时使用，与 --template-id 二选一）
 - `--template-id`：已有模板 ID（重新构建时使用，与 --name 二选一，必须同时提供 `--dockerfile`）
-- `--from-image`：基础 Docker 镜像
-- `--from-template`：基础模板
+- `--from-image`：基础 Docker 镜像，仅创建新模板时可用
+- `--from-template`：基础模板，仅创建新模板时可用
 - `--dockerfile`：Dockerfile 路径（启用 v2 构建系统，自动解析 FROM/RUN/COPY 等指令；可与 --from-template 或 --from-image 组合叠加增量步骤）
 - `--path`：构建上下文目录（默认为 Dockerfile 所在目录，与 --dockerfile 配合使用）
 - `--start-cmd`：构建完成后执行的启动命令（Dockerfile 模式下可从 CMD/ENTRYPOINT 自动提取）

--- a/docs/sandbox_template_build.md
+++ b/docs/sandbox_template_build.md
@@ -42,7 +42,7 @@ $ qshell sandbox template build --doc
 # 配置文件
 `sandbox template build` 会按 `CLI flag > 配置文件 > 内置默认值` 合并参数。配置文件可提供 `template_id`、`name`、`dockerfile`、`path`、`from_image`、`from_template`、`start_cmd`、`ready_cmd`、`cpu_count`、`memory_mb` 和 `no_cache`。
 
-首次构建成功且配置文件存在、`template_id` 为空时，命令会自动把新模板 ID 回写到配置文件。更多字段说明见 `docs/sandbox_template_config.md`。
+首次构建成功且配置文件存在、`template_id` 为空时，命令会自动把新模板 ID 回写到配置文件。后续再次运行同一配置文件会进入 rebuild 流程；此时配置文件中保留的 `from_image` / `from_template` 会被忽略，rebuild 只使用 `template_id`、`dockerfile`、资源规格和启动/就绪命令等参数。更多字段说明见 `docs/sandbox_template_config.md`。
 
 # 示例
 1. 从 Docker 镜像创建并构建模板

--- a/docs/sandbox_template_config.md
+++ b/docs/sandbox_template_config.md
@@ -87,6 +87,7 @@ no_cache = false
 - 回写会替换已有的 `template_id` 赋值行（无论原值是否为空），或在文件头插入一行
 - 注释、字段顺序、空白均保留
 - 回写完成后 stdout 打印：`Written template_id to <path> (please commit this file)`
+- `template_id` 存在后再次执行 build 会进入 rebuild 流程，配置文件中保留的 `from_image` / `from_template` 仅作为首次创建记录保留，不参与 rebuild
 
 # 团队协作约定
 

--- a/docs/sandbox_template_config.md
+++ b/docs/sandbox_template_config.md
@@ -1,9 +1,24 @@
-# qshell.sandbox.toml — 模板配置文件
+# 简介
+`sandbox template config`（别名 `cfg`）展示 `qshell.sandbox.toml` 模板配置文件说明。该命令只输出文档，不会读取、创建或修改本地配置文件。
+
+# 格式
+```
+qshell sandbox template config
+qshell sbx tpl cfg
+```
+
+# 帮助文档
+```
+$ qshell sandbox template config -h
+$ qshell sandbox template config --doc
+```
+
+# qshell.sandbox.toml
 
 `qshell sandbox template` 系列命令支持从项目根目录读取 `qshell.sandbox.toml`，
 持久化模板参数并自动管理 `template_id`，方便团队协作与 CI 集成。
 
-## 完整字段说明
+# 完整字段说明
 
 ```toml
 # 模板身份（template_id 由 qshell 首次构建后自动回写，勿手动修改）
@@ -42,13 +57,13 @@ no_cache = false
 | memory_mb | int | 内存（MiB） |
 | no_cache | bool | 强制忽略缓存 |
 
-## 优先级
+# 优先级
 
 `CLI flag > 配置文件 > 内置默认值`
 
 同时提供时，CLI 会覆盖配置文件，并在 stderr 打印一次覆盖提示。
 
-## 构建输入组合
+# 构建输入组合
 
 `from_image` 和 `from_template` 二选一，不能同时设置。
 
@@ -59,13 +74,13 @@ no_cache = false
 
 `from_template + dockerfile` 适合在统一基础模板上叠加少量依赖，例如多个 agent 模板共用一个 `agents-base`。
 
-## 查找规则
+# 查找规则
 
 1. `--config <path>` 显式指定路径（仅 `build` 命令支持）
 2. 当前工作目录下的 `qshell.sandbox.toml`
 3. 未找到时按纯 CLI 模式运行（向后兼容）
 
-## 自动回写行为
+# 自动回写行为
 
 - 首次构建（配置文件存在、`template_id` 为空）成功后，qshell 自动把新的 `template_id` 写入文件
 - 未指定 `--wait` 时，在构建成功启动后回写；指定 `--wait` 时，在构建完成且状态为 `ready` 后回写
@@ -73,14 +88,14 @@ no_cache = false
 - 注释、字段顺序、空白均保留
 - 回写完成后 stdout 打印：`Written template_id to <path> (please commit this file)`
 
-## 团队协作约定
+# 团队协作约定
 
 将 `qshell.sandbox.toml` 加入版本控制：
 - 团队成员克隆仓库后直接 `qshell sandbox template build` 即可重建同一模板
 - CI 脚本只需一行命令，无需维护散落的参数
 - 首次 commit 由构建者完成；后续通常无需修改（除非切换模板）
 
-## 示例：最小项目
+# 示例：最小项目
 
 ```
 my-template/

--- a/iqshell/sandbox/sandbox/operations/create.go
+++ b/iqshell/sandbox/sandbox/operations/create.go
@@ -171,5 +171,28 @@ func parseInlineInjectionFields(spec string) map[string]string {
 }
 
 func parseInlineHeaders(raw string) map[string]string {
-	return sbClient.ParseMetadataMap(raw)
+	m := make(map[string]string)
+	if raw == "" {
+		return m
+	}
+	separator := ";"
+	if !strings.Contains(raw, separator) {
+		separator = ","
+	}
+	for _, pair := range strings.Split(raw, separator) {
+		pair = strings.TrimSpace(pair)
+		if pair == "" {
+			continue
+		}
+		key, value, ok := strings.Cut(pair, "=")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		m[key] = strings.TrimSpace(value)
+	}
+	return m
 }

--- a/iqshell/sandbox/sandbox/operations/create_test.go
+++ b/iqshell/sandbox/sandbox/operations/create_test.go
@@ -51,7 +51,7 @@ func TestBuildSandboxInjections_WithInlineOpenAI(t *testing.T) {
 }
 
 func TestBuildSandboxInjections_WithInlineHTTP(t *testing.T) {
-	injections, err := buildSandboxInjections(nil, []string{"type=http,base-url=https://api.example.com,headers=Authorization=Bearer token,X-Env=prod"})
+	injections, err := buildSandboxInjections(nil, []string{"type=http,base-url=https://api.example.com,headers=Authorization=Bearer token;X-Env=prod"})
 	if err != nil {
 		t.Fatalf("buildSandboxInjections() error = %v", err)
 	}
@@ -120,18 +120,38 @@ func TestBuildSandboxInjections_WithInlineQiniu(t *testing.T) {
 }
 
 func TestParseInlineInjectionFields_HeadersOnly(t *testing.T) {
-	fields := parseInlineInjectionFields("headers=Authorization=Bearer token,X-Env=prod")
-	if got := fields["headers"]; got != "Authorization=Bearer token,X-Env=prod" {
-		t.Fatalf("headers = %q, want %q", got, "Authorization=Bearer token,X-Env=prod")
+	fields := parseInlineInjectionFields("headers=Authorization=Bearer token;X-Env=prod")
+	if got := fields["headers"]; got != "Authorization=Bearer token;X-Env=prod" {
+		t.Fatalf("headers = %q, want %q", got, "Authorization=Bearer token;X-Env=prod")
 	}
 }
 
 func TestParseInlineInjectionFields_HeadersWithOtherFields(t *testing.T) {
-	fields := parseInlineInjectionFields("type=http,base-url=https://api.example.com,headers=Authorization=Bearer token,X-Env=prod")
+	fields := parseInlineInjectionFields("type=http,base-url=https://api.example.com,headers=Authorization=Bearer token;X-Env=prod")
 	if fields["type"] != "http" || fields["base-url"] != "https://api.example.com" {
 		t.Fatalf("fields = %v, want type and base-url parsed", fields)
 	}
-	if got := fields["headers"]; got != "Authorization=Bearer token,X-Env=prod" {
-		t.Fatalf("headers = %q, want %q", got, "Authorization=Bearer token,X-Env=prod")
+	if got := fields["headers"]; got != "Authorization=Bearer token;X-Env=prod" {
+		t.Fatalf("headers = %q, want %q", got, "Authorization=Bearer token;X-Env=prod")
+	}
+}
+
+func TestParseInlineHeaders_SemicolonSeparated(t *testing.T) {
+	headers := parseInlineHeaders("Authorization=Bearer token;X-Env=prod")
+	if len(headers) != 2 {
+		t.Fatalf("headers = %v, want 2 headers", headers)
+	}
+	if headers["Authorization"] != "Bearer token" || headers["X-Env"] != "prod" {
+		t.Fatalf("headers = %v, want parsed headers", headers)
+	}
+}
+
+func TestParseInlineHeaders_CommaFallback(t *testing.T) {
+	headers := parseInlineHeaders("Authorization=Bearer token,X-Env=prod")
+	if len(headers) != 2 {
+		t.Fatalf("headers = %v, want 2 headers", headers)
+	}
+	if headers["Authorization"] != "Bearer token" || headers["X-Env"] != "prod" {
+		t.Fatalf("headers = %v, want parsed headers", headers)
 	}
 }

--- a/iqshell/sandbox/sandbox/operations/exec.go
+++ b/iqshell/sandbox/sandbox/operations/exec.go
@@ -49,8 +49,9 @@ func Exec(info ExecInfo) {
 		return
 	}
 
-	// Build command string
-	cmd := strings.Join(info.Command, " ")
+	// Build command string. The SDK command API accepts a shell command string,
+	// so quote argv-style inputs before joining to preserve spaces and metacharacters.
+	cmd := shellQuoteArgs(info.Command)
 
 	// Build command options
 	var opts []sandbox.CommandOption
@@ -186,4 +187,41 @@ func parseEnvPairs(pairs []string) map[string]string {
 		}
 	}
 	return envs
+}
+
+func shellQuoteArgs(args []string) string {
+	quoted := make([]string, 0, len(args))
+	for _, arg := range args {
+		quoted = append(quoted, shellQuoteArg(arg))
+	}
+	return strings.Join(quoted, " ")
+}
+
+func shellQuoteArg(arg string) string {
+	if arg == "" {
+		return "''"
+	}
+	for _, r := range arg {
+		if !isShellSafeRune(r) {
+			return "'" + strings.ReplaceAll(arg, "'", "'\\''") + "'"
+		}
+	}
+	return arg
+}
+
+func isShellSafeRune(r rune) bool {
+	switch {
+	case r >= 'a' && r <= 'z':
+		return true
+	case r >= 'A' && r <= 'Z':
+		return true
+	case r >= '0' && r <= '9':
+		return true
+	}
+	switch r {
+	case '_', '-', '.', '/', ':', '=', '@', '%', '+', ',':
+		return true
+	default:
+		return false
+	}
 }

--- a/iqshell/sandbox/sandbox/operations/exec_test.go
+++ b/iqshell/sandbox/sandbox/operations/exec_test.go
@@ -43,3 +43,23 @@ func TestParseEnvPairs_MixedValidInvalid(t *testing.T) {
 	result := parseEnvPairs([]string{"GOOD=value", "BAD", "=empty_key", "ALSO_GOOD=123"})
 	assert.Equal(t, map[string]string{"GOOD": "value", "ALSO_GOOD": "123"}, result)
 }
+
+func TestShellQuoteArgs_PreservesSimpleCommand(t *testing.T) {
+	result := shellQuoteArgs([]string{"ls", "-la", "/tmp"})
+	assert.Equal(t, "ls -la /tmp", result)
+}
+
+func TestShellQuoteArgs_QuotesShellCommandString(t *testing.T) {
+	result := shellQuoteArgs([]string{"sh", "-lc", "cat /etc/os-release | head -5"})
+	assert.Equal(t, "sh -lc 'cat /etc/os-release | head -5'", result)
+}
+
+func TestShellQuoteArgs_EscapesSingleQuote(t *testing.T) {
+	result := shellQuoteArgs([]string{"printf", "it's ok"})
+	assert.Equal(t, "printf 'it'\\''s ok'", result)
+}
+
+func TestShellQuoteArgs_QuotesEmptyArg(t *testing.T) {
+	result := shellQuoteArgs([]string{"printf", ""})
+	assert.Equal(t, "printf ''", result)
+}

--- a/iqshell/sandbox/template/operations/build.go
+++ b/iqshell/sandbox/template/operations/build.go
@@ -66,6 +66,8 @@ type BuildInfo struct {
 func Build(info BuildInfo) {
 	// 在合并配置前捕获"CLI 未提供 TemplateID"，以便后续判断是否需要回写。
 	noIDBeforeMerge := info.TemplateID == ""
+	cliFromImage := info.FromImage != ""
+	cliFromTemplate := info.FromTemplate != ""
 
 	// 加载配置文件并合并（CLI > file > default）
 	var cfg *config.FileConfig
@@ -122,6 +124,10 @@ func Build(info BuildInfo) {
 		}
 	}
 
+	if err := normalizeRebuildSourceSelection(&info, cliFromImage, cliFromTemplate); err != nil {
+		sbClient.PrintError("%v", err)
+		return
+	}
 	if err := validateBuildSourceSelection(info); err != nil {
 		sbClient.PrintError("%v", err)
 		return
@@ -401,12 +407,21 @@ func validateBuildSourceSelection(info BuildInfo) error {
 	if info.FromImage != "" && info.FromTemplate != "" {
 		return fmt.Errorf("cannot specify both --from-image and --from-template")
 	}
-	if info.TemplateID != "" && (info.FromImage != "" || info.FromTemplate != "") {
-		return fmt.Errorf("cannot specify --from-image or --from-template when rebuilding an existing template (--template-id)")
-	}
 	if info.Dockerfile == "" && info.FromImage == "" && info.FromTemplate == "" {
 		return fmt.Errorf("--from-image, --from-template, or --dockerfile is required")
 	}
+	return nil
+}
+
+func normalizeRebuildSourceSelection(info *BuildInfo, cliFromImage, cliFromTemplate bool) error {
+	if info.TemplateID == "" || (info.FromImage == "" && info.FromTemplate == "") {
+		return nil
+	}
+	if cliFromImage || cliFromTemplate {
+		return fmt.Errorf("cannot specify --from-image or --from-template when rebuilding an existing template (--template-id)")
+	}
+	info.FromImage = ""
+	info.FromTemplate = ""
 	return nil
 }
 

--- a/iqshell/sandbox/template/operations/build.go
+++ b/iqshell/sandbox/template/operations/build.go
@@ -401,6 +401,9 @@ func validateBuildSourceSelection(info BuildInfo) error {
 	if info.FromImage != "" && info.FromTemplate != "" {
 		return fmt.Errorf("cannot specify both --from-image and --from-template")
 	}
+	if info.TemplateID != "" && (info.FromImage != "" || info.FromTemplate != "") {
+		return fmt.Errorf("cannot specify --from-image or --from-template when rebuilding an existing template (--template-id)")
+	}
 	if info.Dockerfile == "" && info.FromImage == "" && info.FromTemplate == "" {
 		return fmt.Errorf("--from-image, --from-template, or --dockerfile is required")
 	}

--- a/iqshell/sandbox/template/operations/build_test.go
+++ b/iqshell/sandbox/template/operations/build_test.go
@@ -63,28 +63,58 @@ func TestValidateBuildSourceSelection_AllowsDockerfileWithFromTemplate(t *testin
 	assert.NoError(t, err)
 }
 
-func TestValidateBuildSourceSelection_RejectsRebuildWithFromImage(t *testing.T) {
-	err := validateBuildSourceSelection(BuildInfo{
+func TestNormalizeRebuildSourceSelection_RejectsCLIFromImage(t *testing.T) {
+	info := BuildInfo{
 		TemplateID: "tmpl-xxxxxxxxxxxx",
 		Dockerfile: "./Dockerfile",
 		FromImage:  "ubuntu:22.04",
-	})
+	}
+	err := normalizeRebuildSourceSelection(&info, true, false)
 
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "when rebuilding")
 	}
 }
 
-func TestValidateBuildSourceSelection_RejectsRebuildWithFromTemplate(t *testing.T) {
-	err := validateBuildSourceSelection(BuildInfo{
+func TestNormalizeRebuildSourceSelection_RejectsCLIFromTemplate(t *testing.T) {
+	info := BuildInfo{
 		TemplateID:   "tmpl-xxxxxxxxxxxx",
 		Dockerfile:   "./Dockerfile",
 		FromTemplate: "agents-base",
-	})
+	}
+	err := normalizeRebuildSourceSelection(&info, false, true)
 
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "when rebuilding")
 	}
+}
+
+func TestNormalizeRebuildSourceSelection_IgnoresConfigFromImage(t *testing.T) {
+	info := BuildInfo{
+		TemplateID: "tmpl-xxxxxxxxxxxx",
+		Dockerfile: "./Dockerfile",
+		FromImage:  "ubuntu:22.04",
+	}
+
+	err := normalizeRebuildSourceSelection(&info, false, false)
+
+	assert.NoError(t, err)
+	assert.Empty(t, info.FromImage)
+	assert.Empty(t, info.FromTemplate)
+}
+
+func TestNormalizeRebuildSourceSelection_IgnoresConfigFromTemplate(t *testing.T) {
+	info := BuildInfo{
+		TemplateID:   "tmpl-xxxxxxxxxxxx",
+		Dockerfile:   "./Dockerfile",
+		FromTemplate: "agents-base",
+	}
+
+	err := normalizeRebuildSourceSelection(&info, false, false)
+
+	assert.NoError(t, err)
+	assert.Empty(t, info.FromImage)
+	assert.Empty(t, info.FromTemplate)
 }
 
 func TestValidateBuildSourceSelection_RequiresSource(t *testing.T) {

--- a/iqshell/sandbox/template/operations/build_test.go
+++ b/iqshell/sandbox/template/operations/build_test.go
@@ -63,6 +63,30 @@ func TestValidateBuildSourceSelection_AllowsDockerfileWithFromTemplate(t *testin
 	assert.NoError(t, err)
 }
 
+func TestValidateBuildSourceSelection_RejectsRebuildWithFromImage(t *testing.T) {
+	err := validateBuildSourceSelection(BuildInfo{
+		TemplateID: "tmpl-xxxxxxxxxxxx",
+		Dockerfile: "./Dockerfile",
+		FromImage:  "ubuntu:22.04",
+	})
+
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "when rebuilding")
+	}
+}
+
+func TestValidateBuildSourceSelection_RejectsRebuildWithFromTemplate(t *testing.T) {
+	err := validateBuildSourceSelection(BuildInfo{
+		TemplateID:   "tmpl-xxxxxxxxxxxx",
+		Dockerfile:   "./Dockerfile",
+		FromTemplate: "agents-base",
+	})
+
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "when rebuilding")
+	}
+}
+
 func TestValidateBuildSourceSelection_RequiresSource(t *testing.T) {
 	err := validateBuildSourceSelection(BuildInfo{})
 


### PR DESCRIPTION
## 变更内容

- 更新 sandbox / sandbox template / sandbox injection-rule 的 help 文档与子命令示例，补齐多行命令写法，降低长参数示例的阅读成本。
- 为 sandbox、sandbox template、sandbox injection-rule 父命令增加 `NoArgs` 校验，避免未知子命令被当作父命令参数吞掉。
- 补齐 `sandbox template config` / `sbx tpl cfg` 文档入口，并修正 template get、injection-rule alias 等 help 展示细节。
- 修复 `sandbox exec` 将 argv 拼接为 SDK shell command string 时的转义问题，保留空参数、空格、管道、单引号等场景语义。
- 收紧 `sandbox template build --template-id` 重建参数校验，禁止 rebuild 时同时指定 `--from-image` 或 `--from-template`，并同步更新 flag/docs 描述。

## 背景

这轮主要从 sandbox 模块的 CLI 使用体验出发，梳理子命令和参数实现后发现 help/docs 与实际行为存在几处不一致：长示例可读性较差，部分子命令 `-h` 示例滞后，父命令会接受额外参数，模板配置文档无法通过对应命令直接查看，rebuild 参数语义也容易误导用户。

同时，`sandbox exec` 的 SDK 调用接收 shell command string，原先直接 `strings.Join` 会破坏带空格或 shell 元字符的参数，因此补上集中转义并增加单测覆盖。

## 验证

- `gofmt -s -l .`
- `git diff --check`
- `go test ./iqshell/sandbox/sandbox/operations ./iqshell/sandbox/template/operations`
- `go test -tags unit ./cmd_test -run 'TestSandbox'`
- `make test`

`make lint` 仍会因仓库既有 staticcheck 问题失败，失败文件不在本次 sandbox 修改范围内。
