### PR TITLE
chore(release): prepare 2.19.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,16 @@
-# Unreleased
+# 2.19.4
 ## 新增
 1. `qshell sandbox template` 系列命令支持 `qshell.sandbox.toml` 配置文件，可持久化构建参数（name、dockerfile、from_image、cpu_count、memory_mb 等）
 2. `build` 命令新增 `--config` 参数用于显式指定配置文件路径
 3. 首次构建成功后，qshell 自动把新模板的 `template_id` 回写到配置文件，实现后续幂等重建
 4. `get` / `delete` / `publish` 命令在未传入 template_id 时，自动从当前目录 `qshell.sandbox.toml` 读取
+
+## 更新
+1. 升级 `github.com/qiniu/go-sdk/v7` 到 `v7.26.10`
+
+## 修复
+1. 修复 `sandbox template build --rebuild` 未正确申请新的 waiting build 的问题
+2. 修正 sandbox 相关命令帮助信息与参数校验
 
 # 2.19.3
 ## 更新

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 1. 升级 `github.com/qiniu/go-sdk/v7` 到 `v7.26.10`
 
 ## 修复
-1. 修复 `sandbox template build --rebuild` 未正确申请新的 waiting build 的问题
+1. 修复 `sandbox template build` 指定 `--template-id` 重建时未正确申请新的 waiting build 的问题
 2. 修正 sandbox 相关命令帮助信息与参数校验
 
 # 2.19.3


### PR DESCRIPTION
## 概要

准备 qshell 2.19.4 发布：

- 将 CHANGELOG 顶部 `Unreleased` 归档为 `2.19.4`
- 补充本次发布内容：sandbox template 配置文件支持、go-sdk 升级、rebuild 修复、sandbox 帮助与参数校验修复