### PR TITLE
feat(sandbox): 模板按 name 自动 find-or-create

### DIFF
--- a/cmd/sandbox_template.go
+++ b/cmd/sandbox_template.go
@@ -173,8 +173,14 @@ Rebuilding an existing template (--template-id) requires --dockerfile
 because the rebuild API must carry the Dockerfile content in the request body.
 
 参数可通过 qshell.sandbox.toml 持久化；CLI flag 优先于配置文件。
-首次构建成功后，qshell 会自动把 template_id 回写到配置文件，
-后续重建只需 qshell sandbox template build 即可完成幂等重建。`,
+
+模板按 name 定位（同环境内 name 全局唯一）：未提供 --template-id 时，
+qshell 会先按 name 在远端查找；命中即对已有模板触发 rebuild，未命中再创建新模板。
+因此 qshell.sandbox.toml 只需写 name，无需写 template_id，
+配置文件可在多个环境间复用。
+
+向后兼容：toml 中已有 template_id 仍然生效；首次按 --name 创建新模板时，
+qshell 仍会把 template_id 回写到配置文件以备旧脚本使用。`,
 		Example: `  # Create and build a new template from a Docker image
   qshell sandbox template build --name my-template --from-image ubuntu:22.04 --wait
   qshell sbx tpl bd --name my-template --from-image ubuntu:22.04 --wait

--- a/docs/sandbox_template_build.md
+++ b/docs/sandbox_template_build.md
@@ -7,6 +7,8 @@
 
 **重新构建已有模板**（`--template-id`）必须提供 `--dockerfile`——服务端 rebuild 接口要求在请求体中携带 Dockerfile 内容。
 
+未提供 `--template-id` 但提供了 `--name` 时，命令会先在当前环境按 name 查找远端模板；命中则进入 rebuild，未命中才创建新模板。这样 `qshell.sandbox.toml` 可以只保存 `name`，在不同环境中自动定位各自的模板。
+
 支持 `qshell.sandbox.toml` 配置文件、`--config` 显式指定配置文件、`--no-cache` 强制完整构建和 `--wait` 流式查看构建日志。
 
 # 格式
@@ -25,7 +27,7 @@ $ qshell sandbox template build --doc
 需要配置 `QINIU_API_KEY` 或 `E2B_API_KEY` 环境变量。
 
 # 参数
-- `--name`：模板名称（创建新模板时使用，与 --template-id 二选一）
+- `--name`：模板名称。未提供 `--template-id` 时，先按 name 查找远端模板；命中则 rebuild，未命中则创建新模板
 - `--template-id`：已有模板 ID（重新构建时使用，与 --name 二选一，必须同时提供 `--dockerfile`）
 - `--from-image`：基础 Docker 镜像，仅创建新模板时可用
 - `--from-template`：基础模板，仅创建新模板时可用
@@ -42,7 +44,9 @@ $ qshell sandbox template build --doc
 # 配置文件
 `sandbox template build` 会按 `CLI flag > 配置文件 > 内置默认值` 合并参数。配置文件可提供 `template_id`、`name`、`dockerfile`、`path`、`from_image`、`from_template`、`start_cmd`、`ready_cmd`、`cpu_count`、`memory_mb` 和 `no_cache`。
 
-首次构建成功且配置文件存在、`template_id` 为空时，命令会自动把新模板 ID 回写到配置文件。后续再次运行同一配置文件会进入 rebuild 流程；此时配置文件中保留的 `from_image` / `from_template` 会被忽略，rebuild 只使用 `template_id`、`dockerfile`、资源规格和启动/就绪命令等参数。更多字段说明见 `docs/sandbox_template_config.md`。
+未提供 `template_id` 时，如果配置文件或 CLI 中有 `name`，命令会先按 name 在远端查找模板；命中即进入 rebuild，未命中再创建新模板。按 name 命中的 rebuild 不会把 `template_id` 回写到配置文件，便于同一份配置在多个环境复用。
+
+首次创建成功且配置文件存在、`template_id` 为空时，命令会自动把新模板 ID 回写到配置文件，以兼容已有脚本。后续通过 `template_id` 或按 name 命中进入 rebuild 时，配置文件中保留的 `from_image` / `from_template` 会被忽略；如果这两个参数来自 CLI，则命令会报错。更多字段说明见 `docs/sandbox_template_config.md`。
 
 # 示例
 1. 从 Docker 镜像创建并构建模板

--- a/docs/sandbox_template_config.md
+++ b/docs/sandbox_template_config.md
@@ -16,14 +16,16 @@ $ qshell sandbox template config --doc
 # qshell.sandbox.toml
 
 `qshell sandbox template` 系列命令支持从项目根目录读取 `qshell.sandbox.toml`，
-持久化模板参数并自动管理 `template_id`，方便团队协作与 CI 集成。
+持久化模板参数。推荐使用环境无关的 `name` 定位模板；已有的 `template_id` 配置仍保持兼容。
 
 # 完整字段说明
 
 ```toml
-# 模板身份（template_id 由 qshell 首次构建后自动回写，勿手动修改）
-template_id = "tmpl-xxxxxxxxxxxx"
-name        = "claude"
+# 模板身份：推荐只写 name，让不同环境按 name 自动定位各自模板。
+name = "claude"
+
+# 兼容旧配置：已有 template_id 仍优先生效。
+# template_id = "tmpl-xxxxxxxxxxxx"
 
 # 构建输入
 dockerfile    = "./Dockerfile"
@@ -45,8 +47,8 @@ no_cache = false
 
 | 字段 | 类型 | 说明 |
 |------|------|------|
-| template_id | string | 模板 ID，首次构建后自动回写 |
-| name | string | 模板名称（仅创建时使用） |
+| template_id | string | 模板 ID。存在时优先生效，进入 rebuild 流程 |
+| name | string | 模板名称。未提供 template_id 时，build/get/publish/delete/unpublish 会按 name 查找远端模板 |
 | dockerfile | string | Dockerfile 路径 |
 | path | string | 构建上下文目录 |
 | from_image | string | 基础 Docker 镜像 |
@@ -74,27 +76,35 @@ no_cache = false
 
 `from_template + dockerfile` 适合在统一基础模板上叠加少量依赖，例如多个 agent 模板共用一个 `agents-base`。
 
-# 查找规则
+# 配置文件查找规则
 
 1. `--config <path>` 显式指定路径（仅 `build` 命令支持）
 2. 当前工作目录下的 `qshell.sandbox.toml`
 3. 未找到时按纯 CLI 模式运行（向后兼容）
 
+# 模板定位规则
+
+1. 显式传入的 `template_id` 或配置文件中的 `template_id` 优先生效
+2. 未提供 `template_id` 时，使用 `name` 调用远端按 alias 点查
+3. `build` 命中 name 时进入 rebuild；未命中时创建新模板
+4. `get` / `publish` / `delete` / `unpublish` 未传模板 ID 时，也会先从当前目录配置读取 `template_id`，否则按 `name` 查找
+
 # 自动回写行为
 
-- 首次构建（配置文件存在、`template_id` 为空）成功后，qshell 自动把新的 `template_id` 写入文件
+- 首次创建新模板（配置文件存在、`template_id` 为空）成功后，qshell 自动把新的 `template_id` 写入文件，兼容旧脚本
+- 按 `name` 命中已有模板并进入 rebuild 时，不回写 `template_id`，配置文件可继续跨环境复用
 - 未指定 `--wait` 时，在构建成功启动后回写；指定 `--wait` 时，在构建完成且状态为 `ready` 后回写
 - 回写会替换已有的 `template_id` 赋值行（无论原值是否为空），或在文件头插入一行
 - 注释、字段顺序、空白均保留
 - 回写完成后 stdout 打印：`Written template_id to <path> (please commit this file)`
-- `template_id` 存在后再次执行 build 会进入 rebuild 流程，配置文件中保留的 `from_image` / `from_template` 仅作为首次创建记录保留，不参与 rebuild
+- 通过 `template_id` 或按 `name` 命中后再次执行 build 会进入 rebuild 流程，配置文件中保留的 `from_image` / `from_template` 仅作为首次创建记录保留，不参与 rebuild；如果从 CLI 显式传入这两个参数，命令会报错
 
 # 团队协作约定
 
 将 `qshell.sandbox.toml` 加入版本控制：
-- 团队成员克隆仓库后直接 `qshell sandbox template build` 即可重建同一模板
+- 团队成员克隆仓库后直接 `qshell sandbox template build` 即可在当前环境按 `name` 定位或创建模板
 - CI 脚本只需一行命令，无需维护散落的参数
-- 首次 commit 由构建者完成；后续通常无需修改（除非切换模板）
+- 通常只提交 `name` / `dockerfile` / 资源参数即可；如果选择保留 `template_id`，它会固定指向某一个环境里的模板
 
 # 示例：最小项目
 
@@ -115,11 +125,10 @@ memory_mb = 2048
 运行：
 ```bash
 qshell sandbox template build --wait
-# 构建完成后，qshell.sandbox.toml 中 template_id 已被回写
-git add qshell.sandbox.toml && git commit -m "chore: record template_id"
+# 首次运行时未找到同名模板则创建；同名模板已存在则 rebuild
 ```
 
 下次重建：
 ```bash
-qshell sandbox template build --wait  # 幂等，不再 409
+qshell sandbox template build --wait  # 按 name 命中后 rebuild，不再 409
 ```

--- a/docs/sandbox_template_delete.md
+++ b/docs/sandbox_template_delete.md
@@ -17,7 +17,7 @@ $ qshell sandbox template delete --doc
 需要配置 `QINIU_API_KEY` 或 `E2B_API_KEY` 环境变量。
 
 # 参数
-- `templateIDs`：一个或多个模板 ID。未传入时，自动读取当前目录 `qshell.sandbox.toml` 中的 `template_id`
+- `templateIDs`：一个或多个模板 ID。未传入时，自动读取当前目录 `qshell.sandbox.toml`；优先使用 `template_id`，否则按 `name` 查找远端模板
 - `-y, --yes`：跳过确认提示
 
 # 示例
@@ -37,7 +37,7 @@ $ qshell sbx tpl dl tmpl-xxxxxxxxxxxx -y
 $ qshell sandbox template delete tmpl-aaa tmpl-bbb -y
 ```
 
-4. 删除当前目录配置文件对应的模板
+4. 删除当前目录配置文件对应的模板（`template_id` 或 `name`）
 ```
 $ qshell sandbox template delete -y
 $ qshell sbx tpl dl -y

--- a/docs/sandbox_template_get.md
+++ b/docs/sandbox_template_get.md
@@ -17,7 +17,7 @@ $ qshell sandbox template get --doc
 需要配置 `QINIU_API_KEY` 或 `E2B_API_KEY` 环境变量。
 
 # 参数
-- `templateID`：模板 ID。未传入时，自动读取当前目录 `qshell.sandbox.toml` 中的 `template_id`
+- `templateID`：模板 ID。未传入时，自动读取当前目录 `qshell.sandbox.toml`；优先使用 `template_id`，否则按 `name` 查找远端模板
 
 # 示例
 1. 通过参数查看模板详情
@@ -26,7 +26,7 @@ $ qshell sandbox template get tmpl-xxxxxxxxxxxx
 $ qshell sbx tpl gt tmpl-xxxxxxxxxxxx
 ```
 
-2. 读取当前目录 `qshell.sandbox.toml` 中的 `template_id`
+2. 读取当前目录 `qshell.sandbox.toml` 中的 `template_id` 或 `name`
 ```
 $ qshell sandbox template get
 $ qshell sbx tpl gt

--- a/docs/sandbox_template_publish.md
+++ b/docs/sandbox_template_publish.md
@@ -17,7 +17,7 @@ $ qshell sandbox template publish --doc
 需要配置 `QINIU_API_KEY` 或 `E2B_API_KEY` 环境变量。
 
 # 参数
-- `templateIDs`：一个或多个模板 ID。未传入时，自动读取当前目录 `qshell.sandbox.toml` 中的 `template_id`
+- `templateIDs`：一个或多个模板 ID。未传入时，自动读取当前目录 `qshell.sandbox.toml`；优先使用 `template_id`，否则按 `name` 查找远端模板
 - `-y, --yes`：跳过确认提示
 
 # 示例
@@ -32,7 +32,7 @@ $ qshell sbx tpl pb tmpl-xxxxxxxxxxxx -y
 $ qshell sandbox template publish tmpl-aaa tmpl-bbb -y
 ```
 
-3. 发布当前目录配置文件对应的模板
+3. 发布当前目录配置文件对应的模板（`template_id` 或 `name`）
 ```
 $ qshell sandbox template publish -y
 $ qshell sbx tpl pb -y

--- a/docs/sandbox_template_unpublish.md
+++ b/docs/sandbox_template_unpublish.md
@@ -17,7 +17,7 @@ $ qshell sandbox template unpublish --doc
 需要配置 `QINIU_API_KEY` 或 `E2B_API_KEY` 环境变量。
 
 # 参数
-- `templateIDs`：一个或多个模板 ID。未传入时，自动读取当前目录 `qshell.sandbox.toml` 中的 `template_id`
+- `templateIDs`：一个或多个模板 ID。未传入时，自动读取当前目录 `qshell.sandbox.toml`；优先使用 `template_id`，否则按 `name` 查找远端模板
 - `-y, --yes`：跳过确认提示
 
 # 示例
@@ -32,7 +32,7 @@ $ qshell sbx tpl upb tmpl-xxxxxxxxxxxx -y
 $ qshell sandbox template unpublish tmpl-aaa tmpl-bbb -y
 ```
 
-3. 取消发布当前目录配置文件对应的模板
+3. 取消发布当前目录配置文件对应的模板（`template_id` 或 `name`）
 ```
 $ qshell sandbox template unpublish -y
 $ qshell sbx tpl upb -y

--- a/iqshell/sandbox/template/operations/build.go
+++ b/iqshell/sandbox/template/operations/build.go
@@ -142,6 +142,25 @@ func Build(info BuildInfo) {
 	ctx := context.Background()
 	templateID := info.TemplateID
 	buildID := ""
+	// foundByName 表示当前模板是通过 name 在远端查到的；这种情况下
+	// name 已经能稳定定位模板，不再把 template_id 回写进 toml，
+	// 让配置文件保持环境无关。
+	foundByName := false
+
+	// 未提供 --template-id 时，先按 name 在远端查一次：命中即 rebuild，
+	// 未命中再 create。这样多环境切换时无需手工同步 template_id。
+	if templateID == "" && info.Name != "" {
+		existingID, lookupErr := lookupTemplateIDByName(ctx, client, info.Name)
+		if lookupErr != nil {
+			sbClient.PrintError("lookup template by name %q: %v", info.Name, lookupErr)
+			return
+		}
+		if existingID != "" {
+			templateID = existingID
+			foundByName = true
+			fmt.Fprintf(os.Stderr, "[lookup] template %q resolved to %s (rebuild)\n", info.Name, templateID)
+		}
+	}
 
 	if templateID == "" {
 		// 创建新模板
@@ -236,7 +255,7 @@ func Build(info BuildInfo) {
 	}
 
 	if !info.Wait {
-		writeTemplateIDToConfigIfNeeded(cfg, noIDBeforeMerge, templateID)
+		writeTemplateIDToConfigIfNeeded(cfg, noIDBeforeMerge && !foundByName, templateID)
 		fmt.Printf("Build started. Use 'qshell sandbox template builds %s %s' to check status.\n", templateID, buildID)
 		return
 	}
@@ -276,7 +295,7 @@ func Build(info BuildInfo) {
 				sbClient.PrintError("build failed")
 			} else {
 				sbClient.PrintSuccess("Build completed!")
-				writeTemplateIDToConfigIfNeeded(cfg, noIDBeforeMerge, templateID)
+				writeTemplateIDToConfigIfNeeded(cfg, noIDBeforeMerge && !foundByName, templateID)
 			}
 			fmt.Printf("Template ID:  %s\n", buildInfo.TemplateID)
 			fmt.Printf("Build ID:     %s\n", buildInfo.BuildID)

--- a/iqshell/sandbox/template/operations/build.go
+++ b/iqshell/sandbox/template/operations/build.go
@@ -157,8 +157,13 @@ func Build(info BuildInfo) {
 		}
 		if existingID != "" {
 			templateID = existingID
+			info.TemplateID = existingID
 			foundByName = true
 			fmt.Fprintf(os.Stderr, "[lookup] template %q resolved to %s (rebuild)\n", info.Name, templateID)
+			if err := normalizeRebuildSourceSelection(&info, cliFromImage, cliFromTemplate); err != nil {
+				sbClient.PrintError("%v", err)
+				return
+			}
 		}
 	}
 

--- a/iqshell/sandbox/template/operations/config_fallback.go
+++ b/iqshell/sandbox/template/operations/config_fallback.go
@@ -1,6 +1,7 @@
 package operations
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -9,17 +10,49 @@ import (
 )
 
 // templateIDFromCwdConfig 在当前工作目录加载 qshell.sandbox.toml，
-// 返回其中的 template_id。加载/解析失败时打印错误并返回 (""，false)。
-// 文件不存在或未包含 template_id 时返回 ("", true)，由调用方处理。
+// 返回其中可用于定位模板的 template_id。
+//
+// 解析顺序：
+//  1. toml 中的 template_id（向后兼容已有配置）
+//  2. toml 中的 name → 调用 ListTemplates 按 alias 查找
+//
+// 这样 toml 里只写 name（不写 template_id）也能让 publish/get/delete
+// 等命令工作，便于多环境共享同一份配置。
+//
+// 加载/解析失败或远端调用失败时打印错误并返回 (""，false)。
+// 配置文件不存在或既无 template_id 也无 name 时返回 ("", true)，
+// 由调用方决定后续行为。
 func templateIDFromCwdConfig() (string, bool) {
 	cfg, err := config.LoadFromCwd()
 	if err != nil {
 		sbClient.PrintError("load config: %v", err)
 		return "", false
 	}
-	if cfg == nil || cfg.TemplateID == "" {
+	if cfg == nil {
 		return "", true
 	}
-	fmt.Fprintf(os.Stderr, "[config] using template_id from %s\n", cfg.SourcePath())
-	return cfg.TemplateID, true
+	if cfg.TemplateID != "" {
+		fmt.Fprintf(os.Stderr, "[config] using template_id from %s\n", cfg.SourcePath())
+		return cfg.TemplateID, true
+	}
+	if cfg.Name == "" {
+		return "", true
+	}
+
+	client, cErr := sbClient.NewSandboxClient()
+	if cErr != nil {
+		sbClient.PrintError("%v", cErr)
+		return "", false
+	}
+	id, lErr := lookupTemplateIDByName(context.Background(), client, cfg.Name)
+	if lErr != nil {
+		sbClient.PrintError("lookup template by name %q: %v", cfg.Name, lErr)
+		return "", false
+	}
+	if id == "" {
+		return "", true
+	}
+	fmt.Fprintf(os.Stderr, "[lookup] template %q resolved to %s (from %s)\n",
+		cfg.Name, id, cfg.SourcePath())
+	return id, true
 }

--- a/iqshell/sandbox/template/operations/lookup.go
+++ b/iqshell/sandbox/template/operations/lookup.go
@@ -1,0 +1,42 @@
+package operations
+
+import (
+	"context"
+
+	"github.com/qiniu/go-sdk/v7/sandbox"
+)
+
+// lookupTemplateIDByName 在当前环境的模板列表中按 name 查找并返回 template_id。
+// 通过遍历 ListTemplates 结果、匹配 Aliases 实现：后端保证同一环境内 alias 唯一，
+// 因此命中即可作为稳定定位 key 使用。
+//
+// 返回值约定：
+//   - 找到：返回 template_id, nil
+//   - 未找到：返回 "", nil（由调用方决定回退到 create）
+//   - 调用 ListTemplates 出错：返回 "", err
+func lookupTemplateIDByName(ctx context.Context, client *sandbox.Client, name string) (string, error) {
+	if name == "" {
+		return "", nil
+	}
+	templates, err := client.ListTemplates(ctx, nil)
+	if err != nil {
+		return "", err
+	}
+	return findTemplateIDByAlias(templates, name), nil
+}
+
+// findTemplateIDByAlias 在已有模板切片中按 alias 精确匹配并返回 template_id。
+// 未命中返回 ""。提取为纯函数以便单元测试。
+func findTemplateIDByAlias(templates []sandbox.Template, name string) string {
+	if name == "" {
+		return ""
+	}
+	for _, t := range templates {
+		for _, alias := range t.Aliases {
+			if alias == name {
+				return t.TemplateID
+			}
+		}
+	}
+	return ""
+}

--- a/iqshell/sandbox/template/operations/lookup.go
+++ b/iqshell/sandbox/template/operations/lookup.go
@@ -2,41 +2,37 @@ package operations
 
 import (
 	"context"
+	"errors"
+	"net/http"
 
 	"github.com/qiniu/go-sdk/v7/sandbox"
 )
 
-// lookupTemplateIDByName 在当前环境的模板列表中按 name 查找并返回 template_id。
-// 通过遍历 ListTemplates 结果、匹配 Aliases 实现：后端保证同一环境内 alias 唯一，
-// 因此命中即可作为稳定定位 key 使用。
+// lookupTemplateIDByName 在当前环境中按 name 查找并返回 template_id。
+// 后端保证同一环境内 alias 唯一，因此可作为稳定定位 key 使用。
 //
 // 返回值约定：
 //   - 找到：返回 template_id, nil
 //   - 未找到：返回 "", nil（由调用方决定回退到 create）
-//   - 调用 ListTemplates 出错：返回 "", err
+//   - 调用 GetTemplateByAlias 出错：返回 "", err
 func lookupTemplateIDByName(ctx context.Context, client *sandbox.Client, name string) (string, error) {
 	if name == "" {
 		return "", nil
 	}
-	templates, err := client.ListTemplates(ctx, nil)
+	tmpl, err := client.GetTemplateByAlias(ctx, name)
 	if err != nil {
+		if isTemplateAliasNotFound(err) {
+			return "", nil
+		}
 		return "", err
 	}
-	return findTemplateIDByAlias(templates, name), nil
+	return tmpl.TemplateID, nil
 }
 
-// findTemplateIDByAlias 在已有模板切片中按 alias 精确匹配并返回 template_id。
-// 未命中返回 ""。提取为纯函数以便单元测试。
-func findTemplateIDByAlias(templates []sandbox.Template, name string) string {
-	if name == "" {
-		return ""
+func isTemplateAliasNotFound(err error) bool {
+	var apiErr *sandbox.APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.StatusCode == http.StatusNotFound
 	}
-	for _, t := range templates {
-		for _, alias := range t.Aliases {
-			if alias == name {
-				return t.TemplateID
-			}
-		}
-	}
-	return ""
+	return false
 }

--- a/iqshell/sandbox/template/operations/lookup_test.go
+++ b/iqshell/sandbox/template/operations/lookup_test.go
@@ -1,0 +1,49 @@
+package operations
+
+import (
+	"testing"
+
+	"github.com/qiniu/go-sdk/v7/sandbox"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFindTemplateIDByAlias_Hit(t *testing.T) {
+	templates := []sandbox.Template{
+		{TemplateID: "id-base", Aliases: []string{"agents-base"}},
+		{TemplateID: "id-claude", Aliases: []string{"claude"}},
+		{TemplateID: "id-codex", Aliases: []string{"codex"}},
+	}
+
+	assert.Equal(t, "id-claude", findTemplateIDByAlias(templates, "claude"))
+	assert.Equal(t, "id-base", findTemplateIDByAlias(templates, "agents-base"))
+}
+
+func TestFindTemplateIDByAlias_MultipleAliases(t *testing.T) {
+	templates := []sandbox.Template{
+		{TemplateID: "id-claude", Aliases: []string{"claude", "claude-stable"}},
+	}
+
+	assert.Equal(t, "id-claude", findTemplateIDByAlias(templates, "claude-stable"))
+}
+
+func TestFindTemplateIDByAlias_Miss(t *testing.T) {
+	templates := []sandbox.Template{
+		{TemplateID: "id-base", Aliases: []string{"agents-base"}},
+	}
+
+	assert.Equal(t, "", findTemplateIDByAlias(templates, "claude"))
+}
+
+func TestFindTemplateIDByAlias_EmptyName(t *testing.T) {
+	templates := []sandbox.Template{
+		{TemplateID: "id-base", Aliases: []string{"agents-base"}},
+	}
+
+	// 防御性：空 name 不应匹配任何模板，避免误返回第一个 alias 为空字符串的模板。
+	assert.Equal(t, "", findTemplateIDByAlias(templates, ""))
+}
+
+func TestFindTemplateIDByAlias_EmptyTemplates(t *testing.T) {
+	assert.Equal(t, "", findTemplateIDByAlias(nil, "claude"))
+	assert.Equal(t, "", findTemplateIDByAlias([]sandbox.Template{}, "claude"))
+}

--- a/iqshell/sandbox/template/operations/lookup_test.go
+++ b/iqshell/sandbox/template/operations/lookup_test.go
@@ -1,49 +1,33 @@
 package operations
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/qiniu/go-sdk/v7/sandbox"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestFindTemplateIDByAlias_Hit(t *testing.T) {
-	templates := []sandbox.Template{
-		{TemplateID: "id-base", Aliases: []string{"agents-base"}},
-		{TemplateID: "id-claude", Aliases: []string{"claude"}},
-		{TemplateID: "id-codex", Aliases: []string{"codex"}},
-	}
+func TestIsTemplateAliasNotFound_APIError404(t *testing.T) {
+	err := &sandbox.APIError{StatusCode: 404}
 
-	assert.Equal(t, "id-claude", findTemplateIDByAlias(templates, "claude"))
-	assert.Equal(t, "id-base", findTemplateIDByAlias(templates, "agents-base"))
+	assert.True(t, isTemplateAliasNotFound(err))
 }
 
-func TestFindTemplateIDByAlias_MultipleAliases(t *testing.T) {
-	templates := []sandbox.Template{
-		{TemplateID: "id-claude", Aliases: []string{"claude", "claude-stable"}},
-	}
+func TestIsTemplateAliasNotFound_OtherAPIError(t *testing.T) {
+	err := &sandbox.APIError{StatusCode: 500}
 
-	assert.Equal(t, "id-claude", findTemplateIDByAlias(templates, "claude-stable"))
+	assert.False(t, isTemplateAliasNotFound(err))
 }
 
-func TestFindTemplateIDByAlias_Miss(t *testing.T) {
-	templates := []sandbox.Template{
-		{TemplateID: "id-base", Aliases: []string{"agents-base"}},
-	}
+func TestIsTemplateAliasNotFound_WrappedAPIError404(t *testing.T) {
+	err := fmt.Errorf("lookup template: %w", &sandbox.APIError{StatusCode: 404})
 
-	assert.Equal(t, "", findTemplateIDByAlias(templates, "claude"))
+	assert.True(t, isTemplateAliasNotFound(err))
 }
 
-func TestFindTemplateIDByAlias_EmptyName(t *testing.T) {
-	templates := []sandbox.Template{
-		{TemplateID: "id-base", Aliases: []string{"agents-base"}},
-	}
+func TestIsTemplateAliasNotFound_OtherError(t *testing.T) {
+	err := fmt.Errorf("network error")
 
-	// 防御性：空 name 不应匹配任何模板，避免误返回第一个 alias 为空字符串的模板。
-	assert.Equal(t, "", findTemplateIDByAlias(templates, ""))
-}
-
-func TestFindTemplateIDByAlias_EmptyTemplates(t *testing.T) {
-	assert.Equal(t, "", findTemplateIDByAlias(nil, "claude"))
-	assert.Equal(t, "", findTemplateIDByAlias([]sandbox.Template{}, "claude"))
+	assert.False(t, isTemplateAliasNotFound(err))
 }


### PR DESCRIPTION
## 背景

当前 `qshell sandbox template build` 在 toml 中没有 `template_id` 时只能走 create 路径；首次构建成功后 qshell 把 template_id 回写到 toml。

这套机制在**多环境**场景下不友好：同一份 `qshell.sandbox.toml` 切换 `QINIU_SANDBOX_API_URL` 后，原 ID 在新环境不存在，rebuild 直接 404。

## 改动

未提供 `--template-id` 时，build 先按 `name` 在远端 list 中查找：
- 命中 → 对该模板触发 rebuild
- 未命中 → 走原 create 路径

同步扩展 `publish` / `get` / `delete` 共用的 `templateIDFromCwdConfig`，
toml 仅有 `name` 时也能解析到 ID。

## 行为变化

- `qshell.sandbox.toml` 可以**只写 `name`**，无需写 `template_id`，跨环境共享同一份配置
- by-name 命中走 rebuild 时**不再回写** template_id（保留 name 作为 source of truth）
- 向后兼容：
  - toml 中已有 `template_id` 仍优先生效
  - `--name` 首次创建新模板时仍回写 template_id（兼容旧脚本）

## 测试

- `go test ./iqshell/sandbox/template/operations/...` 全绿
- 新增 `lookup_test.go`：5 个用例覆盖命中 / 多 alias / 未命中 / 空 name / 空切片
- 在新环境（us-south-1）实际跑通：claude 模板按 name 命中已存在的 ID 并 rebuild 成功