### PR TITLE
fix(sandbox): rebuild 路径保留 TOML 中的 from_template / from_image

### DIFF
--- a/docs/sandbox_template_build.md
+++ b/docs/sandbox_template_build.md
@@ -46,7 +46,7 @@ $ qshell sandbox template build --doc
 
 未提供 `template_id` 时，如果配置文件或 CLI 中有 `name`，命令会先按 name 在远端查找模板；命中即进入 rebuild，未命中再创建新模板。按 name 命中的 rebuild 不会把 `template_id` 回写到配置文件，便于同一份配置在多个环境复用。
 
-首次创建成功且配置文件存在、`template_id` 为空时，命令会自动把新模板 ID 回写到配置文件，以兼容已有脚本。后续通过 `template_id` 或按 name 命中进入 rebuild 时，配置文件中保留的 `from_image` / `from_template` 会被忽略；如果这两个参数来自 CLI，则命令会报错。更多字段说明见 `docs/sandbox_template_config.md`。
+首次创建成功且配置文件存在、`template_id` 为空时，命令会自动把新模板 ID 回写到配置文件，以兼容已有脚本。后续通过 `template_id` 或按 name 命中进入 rebuild 时，配置文件中保留的 `from_image` / `from_template` 会继续参与构建；如果这两个参数来自 CLI，则命令会报错。更多字段说明见 `docs/sandbox_template_config.md`。
 
 # 示例
 1. 从 Docker 镜像创建并构建模板

--- a/docs/sandbox_template_config.md
+++ b/docs/sandbox_template_config.md
@@ -97,7 +97,7 @@ no_cache = false
 - 回写会替换已有的 `template_id` 赋值行（无论原值是否为空），或在文件头插入一行
 - 注释、字段顺序、空白均保留
 - 回写完成后 stdout 打印：`Written template_id to <path> (please commit this file)`
-- 通过 `template_id` 或按 `name` 命中后再次执行 build 会进入 rebuild 流程，配置文件中保留的 `from_image` / `from_template` 仅作为首次创建记录保留，不参与 rebuild；如果从 CLI 显式传入这两个参数，命令会报错
+- 通过 `template_id` 或按 `name` 命中后再次执行 build 会进入 rebuild 流程，配置文件中保留的 `from_image` / `from_template` 会继续参与构建；如果从 CLI 显式传入这两个参数，命令会报错
 
 # 团队协作约定
 

--- a/iqshell/sandbox/template/operations/build.go
+++ b/iqshell/sandbox/template/operations/build.go
@@ -451,11 +451,8 @@ func validateRebuildSourceSelection(info BuildInfo, cliFromImage, cliFromTemplat
 	if info.TemplateID == "" {
 		return nil
 	}
-	if cliFromImage {
-		return fmt.Errorf("cannot specify --from-image when rebuilding an existing template")
-	}
-	if cliFromTemplate {
-		return fmt.Errorf("cannot specify --from-template when rebuilding an existing template")
+	if cliFromImage || cliFromTemplate {
+		return fmt.Errorf("cannot specify --from-image or --from-template when rebuilding an existing template")
 	}
 	return nil
 }

--- a/iqshell/sandbox/template/operations/build.go
+++ b/iqshell/sandbox/template/operations/build.go
@@ -452,7 +452,7 @@ func normalizeRebuildSourceSelection(info *BuildInfo, cliFromImage, cliFromTempl
 		return nil
 	}
 	if cliFromImage || cliFromTemplate {
-		return fmt.Errorf("cannot specify --from-image or --from-template when rebuilding an existing template (--template-id)")
+		return fmt.Errorf("cannot specify --from-image or --from-template when rebuilding an existing template")
 	}
 	return nil
 }

--- a/iqshell/sandbox/template/operations/build.go
+++ b/iqshell/sandbox/template/operations/build.go
@@ -124,7 +124,7 @@ func Build(info BuildInfo) {
 		}
 	}
 
-	if err := normalizeRebuildSourceSelection(&info, cliFromImage, cliFromTemplate); err != nil {
+	if err := validateRebuildSourceSelection(info, cliFromImage, cliFromTemplate); err != nil {
 		sbClient.PrintError("%v", err)
 		return
 	}
@@ -160,7 +160,7 @@ func Build(info BuildInfo) {
 			info.TemplateID = existingID
 			foundByName = true
 			fmt.Fprintf(os.Stderr, "[lookup] template %q resolved to %s (rebuild)\n", info.Name, templateID)
-			if err := normalizeRebuildSourceSelection(&info, cliFromImage, cliFromTemplate); err != nil {
+			if err := validateRebuildSourceSelection(info, cliFromImage, cliFromTemplate); err != nil {
 				sbClient.PrintError("%v", err)
 				return
 			}
@@ -437,7 +437,7 @@ func validateBuildSourceSelection(info BuildInfo) error {
 	return nil
 }
 
-// normalizeRebuildSourceSelection 校验 rebuild 路径下的 from-* 来源。
+// validateRebuildSourceSelection 校验 rebuild 路径下的 from-* 来源。
 //
 // 仅在 CLI 显式提供 --from-image / --from-template 同时又走 rebuild 时报错，
 // 因为这两个参数仅适用于新建模板。
@@ -447,12 +447,15 @@ func validateBuildSourceSelection(info BuildInfo) error {
 // buildFromDockerfile 回退到 Dockerfile 中的 `FROM scratch`，
 // 触发 "image 'scratch' not found"。
 // 现在保留 TOML 来源的值原样透传，让模板继续基于声明的父模板构建。
-func normalizeRebuildSourceSelection(info *BuildInfo, cliFromImage, cliFromTemplate bool) error {
+func validateRebuildSourceSelection(info BuildInfo, cliFromImage, cliFromTemplate bool) error {
 	if info.TemplateID == "" {
 		return nil
 	}
-	if cliFromImage || cliFromTemplate {
-		return fmt.Errorf("cannot specify --from-image or --from-template when rebuilding an existing template")
+	if cliFromImage {
+		return fmt.Errorf("cannot specify --from-image when rebuilding an existing template")
+	}
+	if cliFromTemplate {
+		return fmt.Errorf("cannot specify --from-template when rebuilding an existing template")
 	}
 	return nil
 }

--- a/iqshell/sandbox/template/operations/build.go
+++ b/iqshell/sandbox/template/operations/build.go
@@ -437,15 +437,23 @@ func validateBuildSourceSelection(info BuildInfo) error {
 	return nil
 }
 
+// normalizeRebuildSourceSelection 校验 rebuild 路径下的 from-* 来源。
+//
+// 仅在 CLI 显式提供 --from-image / --from-template 同时又走 rebuild 时报错，
+// 因为这两个参数仅适用于新建模板。
+//
+// 之前的实现会在 rebuild 时把 info.FromImage / info.FromTemplate 清空，
+// 这会丢掉来自 qshell.sandbox.toml 的 from_template，导致下游
+// buildFromDockerfile 回退到 Dockerfile 中的 `FROM scratch`，
+// 触发 "image 'scratch' not found"。
+// 现在保留 TOML 来源的值原样透传，让模板继续基于声明的父模板构建。
 func normalizeRebuildSourceSelection(info *BuildInfo, cliFromImage, cliFromTemplate bool) error {
-	if info.TemplateID == "" || (info.FromImage == "" && info.FromTemplate == "") {
+	if info.TemplateID == "" {
 		return nil
 	}
 	if cliFromImage || cliFromTemplate {
 		return fmt.Errorf("cannot specify --from-image or --from-template when rebuilding an existing template (--template-id)")
 	}
-	info.FromImage = ""
-	info.FromTemplate = ""
 	return nil
 }
 

--- a/iqshell/sandbox/template/operations/build_test.go
+++ b/iqshell/sandbox/template/operations/build_test.go
@@ -89,7 +89,9 @@ func TestNormalizeRebuildSourceSelection_RejectsCLIFromTemplate(t *testing.T) {
 	}
 }
 
-func TestNormalizeRebuildSourceSelection_IgnoresConfigFromImage(t *testing.T) {
+// TOML 配置中声明的 from_image 在 rebuild 时必须保留，
+// 否则下游 buildFromDockerfile 会回退到 Dockerfile 的 FROM 行。
+func TestNormalizeRebuildSourceSelection_PreservesConfigFromImage(t *testing.T) {
 	info := BuildInfo{
 		TemplateID: "tmpl-xxxxxxxxxxxx",
 		Dockerfile: "./Dockerfile",
@@ -99,22 +101,26 @@ func TestNormalizeRebuildSourceSelection_IgnoresConfigFromImage(t *testing.T) {
 	err := normalizeRebuildSourceSelection(&info, false, false)
 
 	assert.NoError(t, err)
-	assert.Empty(t, info.FromImage)
+	assert.Equal(t, "ubuntu:22.04", info.FromImage)
 	assert.Empty(t, info.FromTemplate)
 }
 
-func TestNormalizeRebuildSourceSelection_IgnoresConfigFromTemplate(t *testing.T) {
+// TOML 配置中声明的 from_template 在 rebuild 时必须保留，
+// 这是修复 "image 'scratch' not found" 的关键场景：
+// agents-base 等模板基于 from_template = "base" 构建，
+// rebuild 时若被清空会让 Dockerfile 中的 FROM scratch 直接送到 builder。
+func TestNormalizeRebuildSourceSelection_PreservesConfigFromTemplate(t *testing.T) {
 	info := BuildInfo{
 		TemplateID:   "tmpl-xxxxxxxxxxxx",
 		Dockerfile:   "./Dockerfile",
-		FromTemplate: "agents-base",
+		FromTemplate: "base",
 	}
 
 	err := normalizeRebuildSourceSelection(&info, false, false)
 
 	assert.NoError(t, err)
 	assert.Empty(t, info.FromImage)
-	assert.Empty(t, info.FromTemplate)
+	assert.Equal(t, "base", info.FromTemplate)
 }
 
 func TestValidateBuildSourceSelection_RequiresSource(t *testing.T) {

--- a/iqshell/sandbox/template/operations/build_test.go
+++ b/iqshell/sandbox/template/operations/build_test.go
@@ -73,6 +73,7 @@ func TestValidateRebuildSourceSelection_RejectsCLIFromImage(t *testing.T) {
 
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "--from-image")
+		assert.Contains(t, err.Error(), "--from-template")
 	}
 }
 
@@ -85,6 +86,7 @@ func TestValidateRebuildSourceSelection_RejectsCLIFromTemplate(t *testing.T) {
 	err := validateRebuildSourceSelection(info, false, true)
 
 	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "--from-image")
 		assert.Contains(t, err.Error(), "--from-template")
 	}
 }

--- a/iqshell/sandbox/template/operations/build_test.go
+++ b/iqshell/sandbox/template/operations/build_test.go
@@ -63,42 +63,42 @@ func TestValidateBuildSourceSelection_AllowsDockerfileWithFromTemplate(t *testin
 	assert.NoError(t, err)
 }
 
-func TestNormalizeRebuildSourceSelection_RejectsCLIFromImage(t *testing.T) {
+func TestValidateRebuildSourceSelection_RejectsCLIFromImage(t *testing.T) {
 	info := BuildInfo{
 		TemplateID: "tmpl-xxxxxxxxxxxx",
 		Dockerfile: "./Dockerfile",
 		FromImage:  "ubuntu:22.04",
 	}
-	err := normalizeRebuildSourceSelection(&info, true, false)
+	err := validateRebuildSourceSelection(info, true, false)
 
 	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "when rebuilding")
+		assert.Contains(t, err.Error(), "--from-image")
 	}
 }
 
-func TestNormalizeRebuildSourceSelection_RejectsCLIFromTemplate(t *testing.T) {
+func TestValidateRebuildSourceSelection_RejectsCLIFromTemplate(t *testing.T) {
 	info := BuildInfo{
 		TemplateID:   "tmpl-xxxxxxxxxxxx",
 		Dockerfile:   "./Dockerfile",
 		FromTemplate: "agents-base",
 	}
-	err := normalizeRebuildSourceSelection(&info, false, true)
+	err := validateRebuildSourceSelection(info, false, true)
 
 	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "when rebuilding")
+		assert.Contains(t, err.Error(), "--from-template")
 	}
 }
 
 // TOML 配置中声明的 from_image 在 rebuild 时必须保留，
 // 否则下游 buildFromDockerfile 会回退到 Dockerfile 的 FROM 行。
-func TestNormalizeRebuildSourceSelection_PreservesConfigFromImage(t *testing.T) {
+func TestValidateRebuildSourceSelection_PreservesConfigFromImage(t *testing.T) {
 	info := BuildInfo{
 		TemplateID: "tmpl-xxxxxxxxxxxx",
 		Dockerfile: "./Dockerfile",
 		FromImage:  "ubuntu:22.04",
 	}
 
-	err := normalizeRebuildSourceSelection(&info, false, false)
+	err := validateRebuildSourceSelection(info, false, false)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "ubuntu:22.04", info.FromImage)
@@ -109,14 +109,14 @@ func TestNormalizeRebuildSourceSelection_PreservesConfigFromImage(t *testing.T) 
 // 这是修复 "image 'scratch' not found" 的关键场景：
 // agents-base 等模板基于 from_template = "base" 构建，
 // rebuild 时若被清空会让 Dockerfile 中的 FROM scratch 直接送到 builder。
-func TestNormalizeRebuildSourceSelection_PreservesConfigFromTemplate(t *testing.T) {
+func TestValidateRebuildSourceSelection_PreservesConfigFromTemplate(t *testing.T) {
 	info := BuildInfo{
 		TemplateID:   "tmpl-xxxxxxxxxxxx",
 		Dockerfile:   "./Dockerfile",
 		FromTemplate: "base",
 	}
 
-	err := normalizeRebuildSourceSelection(&info, false, false)
+	err := validateRebuildSourceSelection(info, false, false)
 
 	assert.NoError(t, err)
 	assert.Empty(t, info.FromImage)


### PR DESCRIPTION
## 背景

#445 / v2.19.5 引入了按 name 自动 find-or-create 的能力，让多环境共享同一份 \`qshell.sandbox.toml\`。但实际使用中发现：当模板已存在、走 rebuild 路径时，TOML 中的 \`from_template\`（或 \`from_image\`）会被静默清空。

下游 \`buildFromDockerfile\` 在拼 \`StartTemplateBuildParams\` 时落到 \`default\` 分支，把 Dockerfile 中的 \`FROM scratch\` 当作真实 base 送到 builder，触发：

\`\`\`
ERROR: image 'scratch' not found
\`\`\`

复现场景：sandbox 项目中 \`templates/agents-base/Dockerfile\` 用 \`FROM scratch\` 作为占位、由 \`from_template = \"base\"\` 提供真实底座。首次 build 通过 create 路径，\`from_template\` 直接透传给 \`StartTemplateBuild\`；之后任何 rebuild 都会因清空逻辑失败。

## 修复

\`normalizeRebuildSourceSelection\` 仅保留对 CLI 显式 \`--from-image\` / \`--from-template\` + \`--template-id\` 组合的报错，不再清空 \`info.FromImage / info.FromTemplate\`。来自 TOML 的值代表模板的固有声明，必须在 rebuild 时透传。

## 验证

\`\`\`
go test ./iqshell/sandbox/template/operations/...
\`\`\`

新增 / 调整测试：
- \`TestNormalizeRebuildSourceSelection_PreservesConfigFromImage\`：rebuild 保留 TOML \`from_image\`
- \`TestNormalizeRebuildSourceSelection_PreservesConfigFromTemplate\`：rebuild 保留 TOML \`from_template\`（修复关键场景）
- \`TestNormalizeRebuildSourceSelection_RejectsCLIFromImage\` / \`RejectsCLIFromTemplate\` 仍通过

## 影响面

- 兼容性：CLI 行为不变（--template-id + --from-* 仍报错）
- 仅修复 TOML-driven 流程，无新增配置或参数

## Test plan
- [x] 单元测试通过
- [ ] 在国内 / 海外两套 sandbox 环境上 \`make build\` 全套模板验证 rebuild 链路