### PR TITLE
feat(sandbox): 支持挂载 Kodo bucket 资源

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# qshell sandbox API key. Prefer QINIU_API_KEY; E2B_API_KEY is kept for compatibility.
+export QINIU_API_KEY=your-qiniu-sandbox-api-key
+# export E2B_API_KEY=your-e2b-compatible-api-key
+
+# Optional sandbox API endpoint override. Leave unset to use the SDK default:
+# https://cn-yangzhou-1-sandbox.qiniuapi.com
+# export QINIU_SANDBOX_API_URL=https://cn-yangzhou-1-sandbox.qiniuapi.com
+
+# Qiniu AK/SK fallback. These are required when no active `qshell user` account
+# is available, and are needed for features such as `sandbox create --resource type=kodo`.
+export QINIU_ACCESS_KEY=your-qiniu-access-key
+export QINIU_SECRET_KEY=your-qiniu-secret-key
+
+# Optional values for manual sandbox resource testing.
+export QSHELL_SANDBOX_TEMPLATE_ID=your-template-id
+export QSHELL_SANDBOX_KODO_BUCKET=your-kodo-bucket
+export QSHELL_SANDBOX_KODO_PREFIX=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 ## 新增
 1. `qshell sandbox injection-rule create` / `update` 与 `qshell sandbox create --inline-injection` 新增 `github` 注入类型：通过 `--api-key` / `api-key=` 传入 GitHub Token；平台克隆仓库及匹配 `github.com` / `api.github.com` 出站请求时自动注入 token，沙箱内不可见明文
 2. `qshell sandbox create` 新增 `--resource` 参数，支持在沙箱启动前由平台拉取 GitHub 仓库快照并挂载到指定路径，格式 `type=github_repository,url=<url>,mount-path=<absPath>,token=<token>`（`type` 可省略，`mount-path` 也可写作 `mount`；同一沙箱内多条 `--resource` 必须共用同一 token）
+3. `qshell sandbox create --resource` 支持挂载 Kodo bucket 资源，格式 `type=kodo,bucket=<bucket>,mount-path=<absPath>[,prefix=<prefix>][,read-only=<bool>]`
 
 ## 更新
 1. 升级 `github.com/qiniu/go-sdk/v7` 到 `v7.26.12`，附带修复其内部 `Commands.Connect` 重复关闭 channel 引发的 panic，并对 `GitRepositoryResource` 必填字段进行 SDK 侧校验
+2. 升级 `github.com/qiniu/go-sdk/v7` 到 `v7.26.13`，跟进 SDK 的 Kodo bucket resource 支持
 
 # 2.19.6
 ## 修复

--- a/cmd/sandbox.go
+++ b/cmd/sandbox.go
@@ -130,7 +130,11 @@ var sandboxCreateCmdBuilder = func(cfg *iqshell.Config) *cobra.Command {
   qshell sandbox create my-template \
     --resource 'type=github_repository,url=https://github.com/owner/repo.git,mount-path=/workspace/repo,token=ghp-xxx'
   qshell sbx cr my-template \
-    --resource 'url=https://github.com/owner/repo.git,mount-path=/workspace/repo,token=ghp-xxx'`,
+    --resource 'url=https://github.com/owner/repo.git,mount-path=/workspace/repo,token=ghp-xxx'
+
+  # Create with a Kodo bucket resource mounted into the sandbox
+  qshell sandbox create my-template \
+    --resource 'type=kodo,bucket=my-bucket,mount-path=/mnt/kodo,prefix=datasets/,read-only=true'`,
 		Args: cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			cfg.CmdCfg.CmdId = docs.SandboxCreateType
@@ -150,7 +154,7 @@ var sandboxCreateCmdBuilder = func(cfg *iqshell.Config) *cobra.Command {
 	cmd.Flags().BoolVar(&info.AutoPause, "auto-pause", false, "automatically pause sandbox when timeout expires (instead of killing)")
 	cmd.Flags().StringArrayVar(&info.InjectionRuleID, "injection-rule", nil, "injection rule IDs to apply when creating the sandbox (can be specified multiple times)")
 	cmd.Flags().StringArrayVar(&info.InlineInjection, "inline-injection", nil, "inline injection spec to apply when creating the sandbox (can be specified multiple times, format: type=<type>,api-key=<key>,base-url=<url>,headers=<k1=v1;k2=v2>)")
-	cmd.Flags().StringArrayVar(&info.Resources, "resource", nil, "resource to mount before sandbox starts (can be specified multiple times, format: type=github_repository,url=<url>,mount-path=<absPath>,token=<token>; warning: passing tokens via CLI may leak through shell history or process lists)")
+	cmd.Flags().StringArrayVar(&info.Resources, "resource", nil, "resource to mount before sandbox starts (can be specified multiple times, formats: type=github_repository,url=<url>,mount-path=<absPath>,token=<token> or type=kodo,bucket=<bucket>,mount-path=<absPath>,prefix=<prefix>,read-only=<bool>; warning: passing tokens via CLI may leak through shell history or process lists)")
 	return cmd
 }
 

--- a/docs/sandbox_create.md
+++ b/docs/sandbox_create.md
@@ -20,6 +20,8 @@ $ qshell sandbox create --doc
 # 鉴权
 需要配置 `QINIU_API_KEY` 或 `E2B_API_KEY` 环境变量，或在当前目录 `.env` 文件中设置。
 
+使用 `--resource type=kodo` 挂载 Kodo bucket 时，还需要 qshell 能获取七牛 AK/SK 凭据（优先使用 `qshell user` 当前账号，环境变量 `QINIU_ACCESS_KEY` / `QINIU_SECRET_KEY` 作为兜底）。
+
 # 参数
 - `template`：模板 ID（实际创建时必填；命令参数层最多接受 1 个模板参数）
 - `-t, --timeout`：沙箱超时时间（秒）
@@ -29,12 +31,13 @@ $ qshell sandbox create --doc
 - `--auto-pause`：超时后自动暂停沙箱，而不是终止沙箱
 - `--injection-rule`：创建沙箱时附加的注入规则 ID，可多次指定
 - `--inline-injection`：创建沙箱时附加的内联注入配置，可多次指定，格式为 `type=<type>,api-key=<key>,base-url=<url>,headers=<k1=v1;k2=v2>`
-- `--resource`：沙箱启动前挂载的资源规约，可多次指定，格式为 `type=github_repository,url=<url>,mount-path=<absPath>,token=<token>`（`type` 默认为 `github_repository`，`mount-path` 也可写作 `mount`）。注意：通过 CLI 传递 token 可能泄露到 Shell 历史或进程列表
+- `--resource`：沙箱启动前挂载的资源规约，可多次指定。GitHub 仓库格式为 `type=github_repository,url=<url>,mount-path=<absPath>,token=<token>`（`type` 默认为 `github_repository`）；Kodo bucket 格式为 `type=kodo,bucket=<bucket>,mount-path=<absPath>[,prefix=<prefix>][,read-only=<bool>]`；`mount-path` 也可写作 `mount`。注意：通过 CLI 传递 token 可能泄露到 Shell 历史或进程列表
 
 资源说明：
 - `url` 推荐使用 HTTPS 形式（如 `https://github.com/owner/repo.git`）；若 URL 本身包含逗号，当前键值串格式无法正确表达
 - `mount-path` 必须是沙箱内的绝对路径（POSIX），不接受相对路径；同时给出 `mount-path` 与 `mount` 时两者取值必须一致
 - 同一沙箱内多条 `--resource github_repository` 当前必须共用同一 `token`（受 SDK 侧约束）
+- `type=kodo` 使用 `bucket` 指定 Kodo bucket，可用 `prefix` 限制挂载的对象名前缀，可用 `read-only=true` 显式只读挂载
 - `--resource` 与 `--inline-injection type=github` 之间的 token 一致性由平台侧校验，CLI 不做跨参数比较
 
 内联注入说明：
@@ -109,3 +112,11 @@ $ qshell sbx cr my-template \
 ```
 
 > 同一沙箱内多个 `--resource github_repository` 当前必须共用同一 `token`。
+
+11. 创建时挂载 Kodo bucket 资源（沙箱启动前由平台通过 NFS 代理挂载到指定路径）
+```
+$ qshell sandbox create my-template \
+    --resource 'type=kodo,bucket=my-bucket,mount-path=/mnt/kodo,prefix=datasets/,read-only=true'
+$ qshell sbx cr my-template \
+    --resource 'type=kodo,bucket=my-bucket,mount=/mnt/kodo'
+```

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/fatih/color v1.18.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/muesli/termenv v0.16.0
-	github.com/qiniu/go-sdk/v7 v7.26.12
+	github.com/qiniu/go-sdk/v7 v7.26.13
 	github.com/schollz/progressbar/v3 v3.8.6
 	github.com/spf13/cast v1.3.1
 	github.com/spf13/cobra v1.1.3

--- a/go.sum
+++ b/go.sum
@@ -298,6 +298,8 @@ github.com/qiniu/go-sdk/v7 v7.26.11 h1:XVGb5cgqYnNaExCirky+OntL1zvxRxBJuYoWMlnHO
 github.com/qiniu/go-sdk/v7 v7.26.11/go.mod h1:ri7fGwbio0pRDFr8EK5TUpx0DbnpIMJ2bMSDxGWfCbk=
 github.com/qiniu/go-sdk/v7 v7.26.12 h1:AnWiKjBY62XpULoB/MySKdNmlUo9S9pQB7/0s7QueCo=
 github.com/qiniu/go-sdk/v7 v7.26.12/go.mod h1:ri7fGwbio0pRDFr8EK5TUpx0DbnpIMJ2bMSDxGWfCbk=
+github.com/qiniu/go-sdk/v7 v7.26.13 h1:U4usDKoLldAqJntLN4wv4pkAjwvM9dueOUY/wbbO/yM=
+github.com/qiniu/go-sdk/v7 v7.26.13/go.mod h1:ri7fGwbio0pRDFr8EK5TUpx0DbnpIMJ2bMSDxGWfCbk=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=

--- a/iqshell/sandbox/sandbox/operations/create.go
+++ b/iqshell/sandbox/sandbox/operations/create.go
@@ -263,8 +263,12 @@ func parseSandboxResource(spec string) (sandbox.SandboxResourceSpec, error) {
 			res.Prefix = &prefix
 		}
 		readOnly := fields["read-only"]
+		readOnlyAlias := fields["readonly"]
+		if readOnly != "" && readOnlyAlias != "" && readOnly != readOnlyAlias {
+			return sandbox.SandboxResourceSpec{}, fmt.Errorf("invalid resource spec %q: read-only %q and readonly %q conflict, specify only one", spec, readOnly, readOnlyAlias)
+		}
 		if readOnly == "" {
-			readOnly = fields["readonly"]
+			readOnly = readOnlyAlias
 		}
 		if readOnly != "" {
 			value, err := strconv.ParseBool(readOnly)

--- a/iqshell/sandbox/sandbox/operations/create.go
+++ b/iqshell/sandbox/sandbox/operations/create.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"strconv"
 	"strings"
 
 	"github.com/qiniu/go-sdk/v7/sandbox"
@@ -21,7 +22,7 @@ type CreateInfo struct {
 	AutoPause       bool
 	InjectionRuleID []string
 	InlineInjection []string
-	// Resources 沙箱启动前挂载的资源规约（如 GitHub 仓库），格式参见 parseSandboxResource
+	// Resources 沙箱启动前挂载的资源规约（如 GitHub 仓库、Kodo bucket），格式参见 parseSandboxResource
 	Resources []string
 }
 
@@ -213,7 +214,9 @@ func buildSandboxResources(resourceSpecs []string) ([]sandbox.SandboxResourceSpe
 }
 
 // parseSandboxResource 解析单条 --resource 规约。
-// 支持格式：type=github_repository,url=<url>,mount-path=<absPath>,token=<token>
+// 支持格式：
+//   - type=github_repository,url=<url>,mount-path=<absPath>,token=<token>
+//   - type=kodo,bucket=<bucket>,mount-path=<absPath>[,prefix=<prefix>][,read-only=<bool>]
 func parseSandboxResource(spec string) (sandbox.SandboxResourceSpec, error) {
 	fields := sbClient.ParseMetadataMap(spec)
 
@@ -228,22 +231,9 @@ func parseSandboxResource(spec string) (sandbox.SandboxResourceSpec, error) {
 		if url == "" {
 			return sandbox.SandboxResourceSpec{}, fmt.Errorf("invalid resource spec %q: url is required for github_repository", spec)
 		}
-		mountPath := fields["mount-path"]
-		mountAlias := fields["mount"]
-		// 同时给出 mount-path= 与 mount= 且取值不一致时直接报错，避免静默忽略其中一项造成误解
-		if mountPath != "" && mountAlias != "" && mountPath != mountAlias {
-			return sandbox.SandboxResourceSpec{}, fmt.Errorf("invalid resource spec %q: mount-path %q and mount %q conflict, specify only one", spec, mountPath, mountAlias)
-		}
-		if mountPath == "" {
-			// 兼容 mount= 简写
-			mountPath = mountAlias
-		}
-		if mountPath == "" {
-			return sandbox.SandboxResourceSpec{}, fmt.Errorf("invalid resource spec %q: mount-path is required for github_repository", spec)
-		}
-		// 沙箱内部使用 POSIX 路径；用 path.IsAbs 而非 filepath.IsAbs，避免 Windows 主机上把 /workspace 误判为相对
-		if !path.IsAbs(mountPath) {
-			return sandbox.SandboxResourceSpec{}, fmt.Errorf("invalid resource spec %q: mount-path %q must be an absolute path", spec, mountPath)
+		mountPath, err := parseSandboxResourceMountPath(spec, fields, "github_repository")
+		if err != nil {
+			return sandbox.SandboxResourceSpec{}, err
 		}
 		token := fields["token"]
 		if token == "" {
@@ -256,9 +246,58 @@ func parseSandboxResource(spec string) (sandbox.SandboxResourceSpec, error) {
 			AuthorizationToken: &token,
 		}
 		return sandbox.SandboxResourceSpec{GitRepository: res}, nil
+	case "kodo":
+		bucket := fields["bucket"]
+		if bucket == "" {
+			return sandbox.SandboxResourceSpec{}, fmt.Errorf("invalid resource spec %q: bucket is required for kodo", spec)
+		}
+		mountPath, err := parseSandboxResourceMountPath(spec, fields, "kodo")
+		if err != nil {
+			return sandbox.SandboxResourceSpec{}, err
+		}
+		res := &sandbox.KodoResource{
+			Bucket:    bucket,
+			MountPath: mountPath,
+		}
+		if prefix := fields["prefix"]; prefix != "" {
+			res.Prefix = &prefix
+		}
+		readOnly := fields["read-only"]
+		if readOnly == "" {
+			readOnly = fields["readonly"]
+		}
+		if readOnly != "" {
+			value, err := strconv.ParseBool(readOnly)
+			if err != nil {
+				return sandbox.SandboxResourceSpec{}, fmt.Errorf("invalid resource spec %q: read-only %q must be a boolean", spec, readOnly)
+			}
+			res.ReadOnly = &value
+		}
+		return sandbox.SandboxResourceSpec{Kodo: res}, nil
 	default:
-		return sandbox.SandboxResourceSpec{}, fmt.Errorf("invalid resource spec %q: unsupported type %q (supported: github_repository)", spec, typ)
+		return sandbox.SandboxResourceSpec{}, fmt.Errorf("invalid resource spec %q: unsupported type %q (supported: github_repository, kodo)", spec, typ)
 	}
+}
+
+func parseSandboxResourceMountPath(spec string, fields map[string]string, resourceType string) (string, error) {
+	mountPath := fields["mount-path"]
+	mountAlias := fields["mount"]
+	// 同时给出 mount-path= 与 mount= 且取值不一致时直接报错，避免静默忽略其中一项造成误解
+	if mountPath != "" && mountAlias != "" && mountPath != mountAlias {
+		return "", fmt.Errorf("invalid resource spec %q: mount-path %q and mount %q conflict, specify only one", spec, mountPath, mountAlias)
+	}
+	if mountPath == "" {
+		// 兼容 mount= 简写
+		mountPath = mountAlias
+	}
+	if mountPath == "" {
+		return "", fmt.Errorf("invalid resource spec %q: mount-path is required for %s", spec, resourceType)
+	}
+	// 沙箱内部使用 POSIX 路径；用 path.IsAbs 而非 filepath.IsAbs，避免 Windows 主机上把 /workspace 误判为相对
+	if !path.IsAbs(mountPath) {
+		return "", fmt.Errorf("invalid resource spec %q: mount-path %q must be an absolute path", spec, mountPath)
+	}
+	return mountPath, nil
 }
 
 func parseInlineHeaders(raw string) map[string]string {

--- a/iqshell/sandbox/sandbox/operations/create_test.go
+++ b/iqshell/sandbox/sandbox/operations/create_test.go
@@ -222,6 +222,53 @@ func TestBuildSandboxResources_DefaultsTypeAndAcceptsMountAlias(t *testing.T) {
 	}
 }
 
+func TestBuildSandboxResources_Kodo(t *testing.T) {
+	resources, err := buildSandboxResources([]string{
+		"type=kodo,bucket=test-bucket,mount-path=/mnt/kodo,prefix=datasets/,read-only=true",
+	})
+	if err != nil {
+		t.Fatalf("buildSandboxResources() error = %v", err)
+	}
+	if len(resources) != 1 {
+		t.Fatalf("buildSandboxResources() len = %d, want 1", len(resources))
+	}
+	got := resources[0].Kodo
+	if got == nil {
+		t.Fatalf("resource = %+v, want Kodo set", resources[0])
+	}
+	if got.Bucket != "test-bucket" {
+		t.Fatalf("bucket = %q, want test-bucket", got.Bucket)
+	}
+	if got.MountPath != "/mnt/kodo" {
+		t.Fatalf("mount path = %q, want /mnt/kodo", got.MountPath)
+	}
+	if got.Prefix == nil || *got.Prefix != "datasets/" {
+		t.Fatalf("prefix = %v, want datasets/", got.Prefix)
+	}
+	if got.ReadOnly == nil || !*got.ReadOnly {
+		t.Fatalf("read-only = %v, want true", got.ReadOnly)
+	}
+}
+
+func TestBuildSandboxResources_KodoAcceptsMountAliasAndReadonlyAlias(t *testing.T) {
+	resources, err := buildSandboxResources([]string{
+		"type=kodo,bucket=test-bucket,mount=/mnt/kodo,readonly=false",
+	})
+	if err != nil {
+		t.Fatalf("buildSandboxResources() error = %v", err)
+	}
+	got := resources[0].Kodo
+	if got == nil {
+		t.Fatal("resource Kodo = nil, want set")
+	}
+	if got.MountPath != "/mnt/kodo" {
+		t.Fatalf("mount path via mount= alias = %q, want /mnt/kodo", got.MountPath)
+	}
+	if got.ReadOnly == nil || *got.ReadOnly {
+		t.Fatalf("readonly alias = %v, want false", got.ReadOnly)
+	}
+}
+
 func TestBuildSandboxResources_RejectsMissingURL(t *testing.T) {
 	if _, err := buildSandboxResources([]string{"type=github_repository,mount-path=/workspace"}); err == nil {
 		t.Fatal("expected missing url to fail")
@@ -243,6 +290,24 @@ func TestBuildSandboxResources_RejectsMissingToken(t *testing.T) {
 func TestBuildSandboxResources_RejectsRelativeMountPath(t *testing.T) {
 	if _, err := buildSandboxResources([]string{"url=https://github.com/owner/repo.git,mount-path=workspace/repo,token=ghp-xxx"}); err == nil {
 		t.Fatal("expected relative mount-path to fail")
+	}
+}
+
+func TestBuildSandboxResources_RejectsKodoMissingBucket(t *testing.T) {
+	if _, err := buildSandboxResources([]string{"type=kodo,mount-path=/mnt/kodo"}); err == nil {
+		t.Fatal("expected missing kodo bucket to fail")
+	}
+}
+
+func TestBuildSandboxResources_RejectsKodoMissingMountPath(t *testing.T) {
+	if _, err := buildSandboxResources([]string{"type=kodo,bucket=test-bucket"}); err == nil {
+		t.Fatal("expected missing kodo mount-path to fail")
+	}
+}
+
+func TestBuildSandboxResources_RejectsKodoInvalidReadOnly(t *testing.T) {
+	if _, err := buildSandboxResources([]string{"type=kodo,bucket=test-bucket,mount-path=/mnt/kodo,read-only=maybe"}); err == nil {
+		t.Fatal("expected invalid kodo read-only to fail")
 	}
 }
 

--- a/iqshell/sandbox/sandbox/operations/create_test.go
+++ b/iqshell/sandbox/sandbox/operations/create_test.go
@@ -311,6 +311,12 @@ func TestBuildSandboxResources_RejectsKodoInvalidReadOnly(t *testing.T) {
 	}
 }
 
+func TestBuildSandboxResources_RejectsConflictingReadOnlyAliases(t *testing.T) {
+	if _, err := buildSandboxResources([]string{"type=kodo,bucket=test-bucket,mount-path=/mnt/kodo,read-only=true,readonly=false"}); err == nil {
+		t.Fatal("expected conflicting read-only aliases to fail")
+	}
+}
+
 func TestBuildSandboxResources_RejectsUnsupportedType(t *testing.T) {
 	if _, err := buildSandboxResources([]string{"type=gitlab_repository,url=https://gitlab.com/owner/repo.git,mount-path=/workspace,token=ghp-xxx"}); err == nil {
 		t.Fatal("expected unsupported resource type to fail")


### PR DESCRIPTION
## 变更说明
- 升级 `github.com/qiniu/go-sdk/v7` 到 `v7.26.13`
- `qshell sandbox create --resource` 支持通过 `type=kodo` 挂载 Kodo bucket
- 补充 sandbox resource 鉴权说明，并新增 `.env.example` 便于手动集成测试

## 验证方式
- `git diff --check`
- `go test ./iqshell/sandbox/sandbox/operations`
- `make test`
- `staticcheck ./iqshell/sandbox/sandbox/operations`
- 使用 `.env.prod` 做真实 sandbox 集成验证：只读挂载 Kodo bucket，确认可列目录且写入被拒绝
- 使用可写挂载做真实 sandbox 集成验证：写入并读回 `qshell-kodo-write-test-20260612T093038Z.txt`，随后清理 sandbox 并确认无运行中实例残留

## 备注
- `make lint` 全量仍会报仓库既有的 staticcheck 问题，均不在本次改动范围内；本次触达的 sandbox operations 包已通过 staticcheck。
