### PR TITLE
feat(sandbox): 支持注入规则匹配条件

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 2.19.9 (unreleased)
+## 新增
+1. `qshell sandbox injection-rule create` / `update` 新增 `--if-headers` 与 `--if-queries` 参数，用于限制请求注入规则的匹配范围
+2. `qshell sandbox create --inline-injection` 支持 `if-headers=` / `if-queries=` 匹配条件
+3. `github` 注入类型支持通过 `--base-url` / `base-url=` 限制匹配范围，指定时 host 必须为 `github.com` 或 `api.github.com`
+
+## 更新
+1. 升级 `github.com/qiniu/go-sdk/v7` 到 `v7.26.14`，跟进 SDK 的请求注入匹配条件与 GitHub base URL 支持
+
 # 2.19.8 (2026-06-12)
 ## 新增
 1. `qshell sandbox create --resource` 支持挂载 Kodo bucket 资源，格式 `type=kodo,bucket=<bucket>,mount-path=<absPath>[,prefix=<prefix>][,read-only=<bool>]`

--- a/cmd/sandbox.go
+++ b/cmd/sandbox.go
@@ -118,12 +118,12 @@ var sandboxCreateCmdBuilder = func(cfg *iqshell.Config) *cobra.Command {
   # Create with inline injections
   qshell sandbox create my-template \
     --inline-injection 'type=openai,api-key=sk-xxx' \
-    --inline-injection 'type=http,base-url=https://api.example.com,headers=Authorization=Bearer token;X-Env=prod'
+    --inline-injection 'type=http,base-url=https://api.example.com,headers=Authorization=Bearer token;X-Env=prod,if-headers=X-Scope=demo,if-queries=inject=true'
   qshell sbx cr my-template \
     --inline-injection 'type=openai,api-key=sk-xxx'
 
   # Create with a GitHub credential inline injection (token passed via api-key)
-  qshell sandbox create my-template --inline-injection 'type=github,api-key=ghp-xxx'
+  qshell sandbox create my-template --inline-injection 'type=github,api-key=ghp-xxx,base-url=https://api.github.com/repos/qiniu/*'
   qshell sbx cr my-template --inline-injection 'type=github,api-key=ghp-xxx'
 
   # Create with a GitHub repository resource mounted into the sandbox
@@ -153,7 +153,7 @@ var sandboxCreateCmdBuilder = func(cfg *iqshell.Config) *cobra.Command {
 	cmd.Flags().StringArrayVarP(&info.EnvVars, "env-var", "e", nil, "environment variables (KEY=VALUE, can be specified multiple times)")
 	cmd.Flags().BoolVar(&info.AutoPause, "auto-pause", false, "automatically pause sandbox when timeout expires (instead of killing)")
 	cmd.Flags().StringArrayVar(&info.InjectionRuleID, "injection-rule", nil, "injection rule IDs to apply when creating the sandbox (can be specified multiple times)")
-	cmd.Flags().StringArrayVar(&info.InlineInjection, "inline-injection", nil, "inline injection spec to apply when creating the sandbox (can be specified multiple times, format: type=<type>,api-key=<key>,base-url=<url>,headers=<k1=v1;k2=v2>)")
+	cmd.Flags().StringArrayVar(&info.InlineInjection, "inline-injection", nil, "inline injection spec to apply when creating the sandbox (can be specified multiple times, format: type=<type>,api-key=<key>,base-url=<url>,headers=<k1=v1;k2=v2>,if-headers=<k=v>,if-queries=<k=v>)")
 	cmd.Flags().StringArrayVar(&info.Resources, "resource", nil, "resource to mount before sandbox starts (can be specified multiple times, formats: type=github_repository,url=<url>,mount-path=<absPath>,token=<token> or type=kodo,bucket=<bucket>,mount-path=<absPath>,prefix=<prefix>,read-only=<bool>; warning: passing tokens via CLI may leak through shell history or process lists)")
 	return cmd
 }

--- a/cmd/sandbox_injection_rule.go
+++ b/cmd/sandbox_injection_rule.go
@@ -101,13 +101,19 @@ var injectionRuleCreateCmdBuilder = func(cfg *iqshell.Config) *cobra.Command {
   qshell sandbox injection-rule create --name api-auth --type http --base-url https://api.example.com --headers "Authorization=Bearer token123,X-Env=prod"
   qshell sbx ir cr --name api-auth --type http --base-url https://api.example.com --headers "Authorization=Bearer token123,X-Env=prod"
 
+  # Create a scoped HTTP injection rule
+  qshell sandbox injection-rule create --name api-auth-scoped --type http --base-url https://api.example.com --headers "Authorization=Bearer token123" --if-headers "X-Env=prod" --if-queries "inject=true"
+
   # Create a Qiniu AI API injection rule
   qshell sandbox injection-rule create --name qiniu-ai --type qiniu --api-key ak-xxx
   qshell sbx ir cr --name qiniu-ai --type qiniu --api-key ak-xxx
 
   # Create a GitHub credential injection rule (token passed via --api-key)
   qshell sandbox injection-rule create --name github-default --type github --api-key ghp-xxx
-  qshell sbx ir cr --name github-default --type github --api-key ghp-xxx`,
+  qshell sbx ir cr --name github-default --type github --api-key ghp-xxx
+
+  # Create a GitHub credential injection limited to GitHub API repository paths
+  qshell sandbox injection-rule create --name github-api --type github --api-key ghp-xxx --base-url https://api.github.com/repos/qiniu/*`,
 		Run: func(cmd *cobra.Command, args []string) {
 			cfg.CmdCfg.CmdId = docs.SandboxInjectionRuleCreateType
 			if !iqshell.CheckAndLoad(cfg, iqshell.CheckAndLoadInfo{}) {
@@ -119,8 +125,10 @@ var injectionRuleCreateCmdBuilder = func(cfg *iqshell.Config) *cobra.Command {
 	cmd.Flags().StringVar(&info.Name, "name", "", "rule name (required, unique per user)")
 	cmd.Flags().StringVar(&info.Type, "type", "", "injection type: openai, anthropic, gemini, qiniu, github, http")
 	cmd.Flags().StringVar(&info.APIKey, "api-key", "", "API key for openai/anthropic/gemini/qiniu, or token for github (warning: passing secrets via CLI may leak through shell history or process lists)")
-	cmd.Flags().StringVar(&info.BaseURL, "base-url", "", "override base URL or target base URL for http injection")
+	cmd.Flags().StringVar(&info.BaseURL, "base-url", "", "override base URL or target base URL for http/github injection")
 	cmd.Flags().StringVar(&info.Headers, "headers", "", "HTTP headers for custom http injection (comma-separated key=value pairs)")
+	cmd.Flags().StringVar(&info.IfHeaders, "if-headers", "", "request headers that must already match before injection applies (comma-separated key=value pairs)")
+	cmd.Flags().StringVar(&info.IfQueries, "if-queries", "", "query parameters that must already match before injection applies (comma-separated key=value pairs)")
 	_ = cmd.MarkFlagRequired("name")
 	_ = cmd.MarkFlagRequired("type")
 	return cmd
@@ -145,13 +153,19 @@ var injectionRuleUpdateCmdBuilder = func(cfg *iqshell.Config) *cobra.Command {
   qshell sandbox injection-rule update rule-xxxxxxxxxxxx --type http --base-url https://api.example.com --headers "Authorization=Bearer newtoken"
   qshell sbx ir up rule-xxxxxxxxxxxx --type http --base-url https://api.example.com --headers "Authorization=Bearer newtoken"
 
+  # Update custom HTTP matching conditions
+  qshell sandbox injection-rule update rule-xxxxxxxxxxxx --type http --base-url https://api.example.com --headers "Authorization=Bearer newtoken" --if-headers "X-Env=prod" --if-queries "inject=true"
+
   # Update to a Qiniu AI API injection
   qshell sandbox injection-rule update rule-xxxxxxxxxxxx --type qiniu --api-key ak-new
   qshell sbx ir up rule-xxxxxxxxxxxx --type qiniu --api-key ak-new
 
   # Update to a GitHub credential injection (token passed via --api-key)
   qshell sandbox injection-rule update rule-xxxxxxxxxxxx --type github --api-key ghp-new
-  qshell sbx ir up rule-xxxxxxxxxxxx --type github --api-key ghp-new`,
+  qshell sbx ir up rule-xxxxxxxxxxxx --type github --api-key ghp-new
+
+  # Limit GitHub credential injection to GitHub API repository paths
+  qshell sandbox injection-rule update rule-xxxxxxxxxxxx --type github --api-key ghp-new --base-url https://api.github.com/repos/qiniu/*`,
 		Run: func(cmd *cobra.Command, args []string) {
 			cfg.CmdCfg.CmdId = docs.SandboxInjectionRuleUpdateType
 			if !iqshell.CheckAndLoad(cfg, iqshell.CheckAndLoadInfo{}) {
@@ -164,8 +178,10 @@ var injectionRuleUpdateCmdBuilder = func(cfg *iqshell.Config) *cobra.Command {
 	cmd.Flags().StringVar(&info.Name, "name", "", "new rule name")
 	cmd.Flags().StringVar(&info.Type, "type", "", "new injection type: openai, anthropic, gemini, qiniu, github, http")
 	cmd.Flags().StringVar(&info.APIKey, "api-key", "", "new API key for openai/anthropic/gemini/qiniu, or token for github (warning: passing secrets via CLI may leak through shell history or process lists)")
-	cmd.Flags().StringVar(&info.BaseURL, "base-url", "", "new base URL or target base URL for http injection")
+	cmd.Flags().StringVar(&info.BaseURL, "base-url", "", "new base URL or target base URL for http/github injection")
 	cmd.Flags().StringVar(&info.Headers, "headers", "", "new HTTP headers for custom http injection (comma-separated key=value pairs)")
+	cmd.Flags().StringVar(&info.IfHeaders, "if-headers", "", "new request headers that must already match before injection applies (comma-separated key=value pairs)")
+	cmd.Flags().StringVar(&info.IfQueries, "if-queries", "", "new query parameters that must already match before injection applies (comma-separated key=value pairs)")
 	return cmd
 }
 

--- a/docs/sandbox_create.md
+++ b/docs/sandbox_create.md
@@ -30,7 +30,7 @@ $ qshell sandbox create --doc
 - `-e, --env-var`：环境变量（KEY=VALUE 格式，可多次指定）
 - `--auto-pause`：超时后自动暂停沙箱，而不是终止沙箱
 - `--injection-rule`：创建沙箱时附加的注入规则 ID，可多次指定
-- `--inline-injection`：创建沙箱时附加的内联注入配置，可多次指定，格式为 `type=<type>,api-key=<key>,base-url=<url>,headers=<k1=v1;k2=v2>`
+- `--inline-injection`：创建沙箱时附加的内联注入配置，可多次指定，格式为 `type=<type>,api-key=<key>,base-url=<url>,headers=<k1=v1;k2=v2>,if-headers=<k=v>,if-queries=<k=v>`
 - `--resource`：沙箱启动前挂载的资源规约，可多次指定。GitHub 仓库格式为 `type=github_repository,url=<url>,mount-path=<absPath>,token=<token>`（`type` 默认为 `github_repository`）；Kodo bucket 格式为 `type=kodo,bucket=<bucket>,mount-path=<absPath>[,prefix=<prefix>][,read-only=<bool>]`；`mount-path` 也可写作 `mount`。注意：通过 CLI 传递 token 可能泄露到 Shell 历史或进程列表
 
 资源说明：
@@ -43,8 +43,9 @@ $ qshell sandbox create --doc
 内联注入说明：
 - `type` 支持 `openai`、`anthropic`、`gemini`、`qiniu`、`github`、`http`
 - `api-key` 用于 `openai`、`anthropic`、`gemini`、`qiniu` 的 API Key，以及 `github` 的访问 token（token 仅平台可见，沙箱内不可见明文）
-- `base-url` 可用于覆盖默认目标地址；`type=http` 时必填，`type=qiniu` 默认目标地址为 `api.qnaigc.com`；`type=github` 固定匹配 `github.com` / `api.github.com`，不支持配置
+- `base-url` 可用于覆盖默认目标地址；`type=http` 时必填，`type=qiniu` 默认目标地址为 `api.qnaigc.com`；`type=github` 未指定时匹配 `github.com` / `api.github.com`，指定时 host 必须为 `github.com` 或 `api.github.com`
 - `headers` 仅用于 `type=http`，多个请求头使用分号分隔，例如 `headers=Authorization=Bearer token;X-Env=prod`
+- `if-headers` 表示请求 Header 匹配条件，`if-queries` 表示 query 参数匹配条件；多个键值使用分号分隔，例如 `if-headers=X-Scope=demo;X-Env=prod,if-queries=inject=true`
 
 # 示例
 1. 创建沙箱
@@ -93,13 +94,13 @@ $ qshell sbx cr my-template --injection-rule rule-openai --injection-rule rule-h
 ```
 $ qshell sandbox create my-template \
     --inline-injection 'type=openai,api-key=sk-xxx' \
-    --inline-injection 'type=http,base-url=https://api.example.com,headers=Authorization=Bearer token;X-Env=prod'
+    --inline-injection 'type=http,base-url=https://api.example.com,headers=Authorization=Bearer token;X-Env=prod,if-headers=X-Scope=demo,if-queries=inject=true'
 $ qshell sbx cr my-template --inline-injection 'type=gemini,api-key=sk-gem'
 ```
 
 9. 创建时附加 GitHub 凭证注入（token 通过 `api-key` 传入）
 ```
-$ qshell sandbox create my-template --inline-injection 'type=github,api-key=ghp-xxx'
+$ qshell sandbox create my-template --inline-injection 'type=github,api-key=ghp-xxx,base-url=https://api.github.com/repos/qiniu/*'
 $ qshell sbx cr my-template --inline-injection 'type=github,api-key=ghp-xxx'
 ```
 

--- a/docs/sandbox_injection_rule_create.md
+++ b/docs/sandbox_injection_rule_create.md
@@ -4,8 +4,8 @@
 # 格式
 
 ```bash
-qshell sandbox injection-rule create --name <name> --type <openai|anthropic|gemini|qiniu|github|http> [--api-key <apiKey>] [--base-url <baseURL>] [--headers <headers>]
-qshell sbx ir cr --name <name> --type <openai|anthropic|gemini|qiniu|github|http> [--api-key <apiKey>] [--base-url <baseURL>] [--headers <headers>]
+qshell sandbox injection-rule create --name <name> --type <openai|anthropic|gemini|qiniu|github|http> [--api-key <apiKey>] [--base-url <baseURL>] [--headers <headers>] [--if-headers <headers>] [--if-queries <queries>]
+qshell sbx ir cr --name <name> --type <openai|anthropic|gemini|qiniu|github|http> [--api-key <apiKey>] [--base-url <baseURL>] [--headers <headers>] [--if-headers <headers>] [--if-queries <queries>]
 ```
 
 # 帮助文档
@@ -20,8 +20,10 @@ $ qshell sandbox injection-rule create --doc
 - `--name`：规则名称，必填，同一用户下唯一
 - `--type`：注入类型，必填，支持 `openai`、`anthropic`、`gemini`、`qiniu`、`github`、`http`
 - `--api-key`：`openai`、`anthropic`、`gemini`、`qiniu` 类型使用的 API Key，`github` 类型使用的访问 token；`type=github` 时必填。注意：通过 CLI 传递密钥可能泄露到 Shell 历史或进程列表
-- `--base-url`：覆盖默认目标地址，或 `http` 类型的目标基础 URL；`qiniu` 默认为 `api.qnaigc.com`；`github` 类型固定匹配 `github.com` / `api.github.com`，不支持配置
+- `--base-url`：覆盖默认目标地址，或 `http` 类型的目标基础 URL；`qiniu` 默认为 `api.qnaigc.com`；`github` 类型未指定时匹配 `github.com` / `api.github.com`，指定时 host 必须为 `github.com` 或 `api.github.com`
 - `--headers`：`http` 类型的请求头，使用逗号分隔的 `key=value` 形式
+- `--if-headers`：请求 Header 匹配条件，使用逗号分隔的 `key=value` 形式；仅当请求中已存在这些 Header 且值精确匹配时才注入
+- `--if-queries`：请求 query 匹配条件，使用逗号分隔的 `key=value` 形式；仅当请求 URL 中已存在这些 query 参数且值精确匹配时才注入
 
 # 示例
 
@@ -43,6 +45,12 @@ $ qshell sandbox injection-rule create --name anthropic-proxy --type anthropic -
 $ qshell sandbox injection-rule create --name api-auth --type http --base-url https://api.example.com --headers "Authorization=Bearer token123,X-Env=prod"
 ```
 
+创建带匹配条件的自定义 HTTP 注入规则：
+
+```bash
+$ qshell sandbox injection-rule create --name api-auth-scoped --type http --base-url https://api.example.com --headers "Authorization=Bearer token123" --if-headers "X-Scope=demo" --if-queries "inject=true"
+```
+
 创建七牛 AI API 注入规则：
 
 ```bash
@@ -53,4 +61,10 @@ $ qshell sandbox injection-rule create --name qiniu-ai --type qiniu --api-key ak
 
 ```bash
 $ qshell sandbox injection-rule create --name github-default --type github --api-key ghp-xxx
+```
+
+创建仅匹配 GitHub API 仓库路径的 GitHub 凭证注入规则：
+
+```bash
+$ qshell sandbox injection-rule create --name github-api --type github --api-key ghp-xxx --base-url https://api.github.com/repos/qiniu/*
 ```

--- a/docs/sandbox_injection_rule_update.md
+++ b/docs/sandbox_injection_rule_update.md
@@ -4,8 +4,8 @@
 # 格式
 
 ```bash
-qshell sandbox injection-rule update <ruleID> [--name <name>] [--type <openai|anthropic|gemini|qiniu|github|http>] [--api-key <apiKey>] [--base-url <baseURL>] [--headers <headers>]
-qshell sbx ir up <ruleID> [--name <name>] [--type <openai|anthropic|gemini|qiniu|github|http>] [--api-key <apiKey>] [--base-url <baseURL>] [--headers <headers>]
+qshell sandbox injection-rule update <ruleID> [--name <name>] [--type <openai|anthropic|gemini|qiniu|github|http>] [--api-key <apiKey>] [--base-url <baseURL>] [--headers <headers>] [--if-headers <headers>] [--if-queries <queries>]
+qshell sbx ir up <ruleID> [--name <name>] [--type <openai|anthropic|gemini|qiniu|github|http>] [--api-key <apiKey>] [--base-url <baseURL>] [--headers <headers>] [--if-headers <headers>] [--if-queries <queries>]
 ```
 
 # 帮助文档
@@ -21,10 +21,12 @@ $ qshell sandbox injection-rule update --doc
 - `--name`：新的规则名称
 - `--type`：新的注入类型；当需要更新注入配置时必须指定
 - `--api-key`：新的 API Key；更新注入配置时必须与 `--type` 一同指定，且 `type=github` 时必填。注意：通过 CLI 传递密钥可能泄露到 Shell 历史或进程列表
-- `--base-url`：新的基础 URL；更新注入配置时必须与 `--type` 一同指定
+- `--base-url`：新的基础 URL；更新注入配置时必须与 `--type` 一同指定；`github` 类型指定时 host 必须为 `github.com` 或 `api.github.com`
 - `--headers`：新的自定义 HTTP 请求头，使用逗号分隔的 `key=value` 形式；更新时必须与 `--type http` 一同指定
+- `--if-headers`：新的请求 Header 匹配条件，使用逗号分隔的 `key=value` 形式；仅当请求中已存在这些 Header 且值精确匹配时才注入
+- `--if-queries`：新的请求 query 匹配条件，使用逗号分隔的 `key=value` 形式；仅当请求 URL 中已存在这些 query 参数且值精确匹配时才注入
 
-说明：如果只传 `--api-key`、`--base-url` 或 `--headers` 而不传 `--type`，命令会报错，因为当前实现无法从已有规则自动推断要更新的注入类型。
+说明：如果只传 `--api-key`、`--base-url`、`--headers`、`--if-headers` 或 `--if-queries` 而不传 `--type`，命令会报错，因为当前实现无法从已有规则自动推断要更新的注入类型。
 
 # 示例
 
@@ -52,8 +54,20 @@ $ qshell sandbox injection-rule update rule-xxxxxxxxxxxx --type qiniu --api-key 
 $ qshell sandbox injection-rule update rule-xxxxxxxxxxxx --type http --base-url https://api.example.com --headers "Authorization=Bearer newtoken"
 ```
 
+更新自定义 HTTP 匹配条件：
+
+```bash
+$ qshell sandbox injection-rule update rule-xxxxxxxxxxxx --type http --base-url https://api.example.com --headers "Authorization=Bearer newtoken" --if-headers "X-Scope=demo" --if-queries "inject=true"
+```
+
 更新为 GitHub 凭证注入（token 通过 `--api-key` 传入）：
 
 ```bash
 $ qshell sandbox injection-rule update rule-xxxxxxxxxxxx --type github --api-key ghp-new
+```
+
+限制 GitHub 凭证注入的匹配路径：
+
+```bash
+$ qshell sandbox injection-rule update rule-xxxxxxxxxxxx --type github --api-key ghp-new --base-url https://api.github.com/repos/qiniu/*
 ```

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/fatih/color v1.18.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/muesli/termenv v0.16.0
-	github.com/qiniu/go-sdk/v7 v7.26.13
+	github.com/qiniu/go-sdk/v7 v7.26.14
 	github.com/schollz/progressbar/v3 v3.8.6
 	github.com/spf13/cast v1.3.1
 	github.com/spf13/cobra v1.1.3

--- a/go.sum
+++ b/go.sum
@@ -300,6 +300,8 @@ github.com/qiniu/go-sdk/v7 v7.26.12 h1:AnWiKjBY62XpULoB/MySKdNmlUo9S9pQB7/0s7Que
 github.com/qiniu/go-sdk/v7 v7.26.12/go.mod h1:ri7fGwbio0pRDFr8EK5TUpx0DbnpIMJ2bMSDxGWfCbk=
 github.com/qiniu/go-sdk/v7 v7.26.13 h1:U4usDKoLldAqJntLN4wv4pkAjwvM9dueOUY/wbbO/yM=
 github.com/qiniu/go-sdk/v7 v7.26.13/go.mod h1:ri7fGwbio0pRDFr8EK5TUpx0DbnpIMJ2bMSDxGWfCbk=
+github.com/qiniu/go-sdk/v7 v7.26.14 h1:kV9zdvTOM0w9/lgeYffDDw0Fj8FH14/XgCjk4Wb80k8=
+github.com/qiniu/go-sdk/v7 v7.26.14/go.mod h1:ri7fGwbio0pRDFr8EK5TUpx0DbnpIMJ2bMSDxGWfCbk=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=

--- a/iqshell/sandbox/injection_rule/operations/create.go
+++ b/iqshell/sandbox/injection_rule/operations/create.go
@@ -10,11 +10,13 @@ import (
 
 // CreateInfo holds parameters for creating an injection rule.
 type CreateInfo struct {
-	Name    string
-	Type    string
-	APIKey  string
-	BaseURL string
-	Headers string
+	Name      string
+	Type      string
+	APIKey    string
+	BaseURL   string
+	Headers   string
+	IfHeaders string
+	IfQueries string
 }
 
 // Create creates a new injection rule.
@@ -25,10 +27,12 @@ func Create(info CreateInfo) {
 	}
 
 	spec, err := buildInjectionSpec(injectionInput{
-		Type:    info.Type,
-		APIKey:  info.APIKey,
-		BaseURL: info.BaseURL,
-		Headers: info.Headers,
+		Type:      info.Type,
+		APIKey:    info.APIKey,
+		BaseURL:   info.BaseURL,
+		Headers:   info.Headers,
+		IfHeaders: info.IfHeaders,
+		IfQueries: info.IfQueries,
 	})
 	if err != nil {
 		sbClient.PrintError("%v", err)

--- a/iqshell/sandbox/injection_rule/operations/get.go
+++ b/iqshell/sandbox/injection_rule/operations/get.go
@@ -37,6 +37,7 @@ func Get(info GetInfo) {
 	fmt.Printf("Target:       %s\n", formatInjectionTarget(rule.Injection))
 	fmt.Printf("API Key:      %s\n", yesNo(hasAPIKey(rule.Injection)))
 	fmt.Printf("Headers:      %s\n", formatInjectionHeaders(rule.Injection))
+	fmt.Printf("Conditions:   %s\n", formatInjectionConditions(rule.Injection))
 	fmt.Printf("Created At:   %s\n", sbClient.FormatTimestamp(rule.CreatedAt))
 	fmt.Printf("Updated At:   %s\n", sbClient.FormatTimestamp(rule.UpdatedAt))
 }

--- a/iqshell/sandbox/injection_rule/operations/helpers.go
+++ b/iqshell/sandbox/injection_rule/operations/helpers.go
@@ -24,14 +24,23 @@ const (
 const githubInjectionTarget = "github.com, api.github.com"
 
 type injectionInput struct {
-	Type    string
-	APIKey  string
-	BaseURL string
-	Headers string
+	Type      string
+	APIKey    string
+	BaseURL   string
+	Headers   string
+	IfHeaders string
+	IfQueries string
 }
 
 func buildInjectionSpec(input injectionInput) (sandbox.InjectionSpec, error) {
-	parts, err := sbClient.BuildInjectionParts(input.Type, input.APIKey, input.BaseURL, sbClient.ParseMetadataMap(input.Headers))
+	parts, err := sbClient.BuildInjectionParts(
+		input.Type,
+		input.APIKey,
+		input.BaseURL,
+		sbClient.ParseMetadataMap(input.Headers),
+		sbClient.ParseMetadataMap(input.IfHeaders),
+		sbClient.ParseMetadataMap(input.IfQueries),
+	)
 	if err != nil {
 		return sandbox.InjectionSpec{}, err
 	}
@@ -46,7 +55,12 @@ func buildInjectionSpec(input injectionInput) (sandbox.InjectionSpec, error) {
 }
 
 func shouldUpdateInjection(input injectionInput) bool {
-	return strings.TrimSpace(input.Type) != "" || strings.TrimSpace(input.APIKey) != "" || strings.TrimSpace(input.BaseURL) != "" || strings.TrimSpace(input.Headers) != ""
+	return strings.TrimSpace(input.Type) != "" ||
+		strings.TrimSpace(input.APIKey) != "" ||
+		strings.TrimSpace(input.BaseURL) != "" ||
+		strings.TrimSpace(input.Headers) != "" ||
+		strings.TrimSpace(input.IfHeaders) != "" ||
+		strings.TrimSpace(input.IfQueries) != ""
 }
 
 func formatInjectionType(spec sandbox.InjectionSpec) string {
@@ -79,7 +93,7 @@ func formatInjectionTarget(spec sandbox.InjectionSpec) string {
 	case spec.Qiniu != nil:
 		return optionalValue(spec.Qiniu.BaseURL, "api.qnaigc.com")
 	case spec.Github != nil:
-		return githubInjectionTarget
+		return optionalValue(spec.Github.BaseURL, githubInjectionTarget)
 	case spec.HTTP != nil:
 		return spec.HTTP.BaseURL
 	default:
@@ -91,8 +105,46 @@ func formatInjectionHeaders(spec sandbox.InjectionSpec) string {
 	if spec.HTTP == nil || spec.HTTP.Headers == nil || len(*spec.HTTP.Headers) == 0 {
 		return "-"
 	}
-	keys := make([]string, 0, len(*spec.HTTP.Headers))
-	for k := range *spec.HTTP.Headers {
+	return formatMapKeys(*spec.HTTP.Headers)
+}
+
+func formatInjectionConditions(spec sandbox.InjectionSpec) string {
+	headers, queries := injectionConditions(spec)
+	parts := make([]string, 0, 2)
+	if headers != nil && len(*headers) > 0 {
+		parts = append(parts, "headers: "+formatMapKeys(*headers))
+	}
+	if queries != nil && len(*queries) > 0 {
+		parts = append(parts, "queries: "+formatMapKeys(*queries))
+	}
+	if len(parts) == 0 {
+		return "-"
+	}
+	return strings.Join(parts, "; ")
+}
+
+func injectionConditions(spec sandbox.InjectionSpec) (*map[string]string, *map[string]string) {
+	switch {
+	case spec.OpenAI != nil:
+		return spec.OpenAI.IfHeaders, spec.OpenAI.IfQueries
+	case spec.Anthropic != nil:
+		return spec.Anthropic.IfHeaders, spec.Anthropic.IfQueries
+	case spec.Gemini != nil:
+		return spec.Gemini.IfHeaders, spec.Gemini.IfQueries
+	case spec.Qiniu != nil:
+		return spec.Qiniu.IfHeaders, spec.Qiniu.IfQueries
+	case spec.Github != nil:
+		return spec.Github.IfHeaders, spec.Github.IfQueries
+	case spec.HTTP != nil:
+		return spec.HTTP.IfHeaders, spec.HTTP.IfQueries
+	default:
+		return nil, nil
+	}
+}
+
+func formatMapKeys(m map[string]string) string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
 		keys = append(keys, k)
 	}
 	slices.Sort(keys)

--- a/iqshell/sandbox/injection_rule/operations/helpers_test.go
+++ b/iqshell/sandbox/injection_rule/operations/helpers_test.go
@@ -31,9 +31,11 @@ func TestBuildInjectionSpecOpenAI(t *testing.T) {
 
 func TestBuildInjectionSpecHTTP(t *testing.T) {
 	spec, err := buildInjectionSpec(injectionInput{
-		Type:    injectionTypeHTTP,
-		BaseURL: "https://api.example.com",
-		Headers: "Authorization=Bearer token,X-Env=prod",
+		Type:      injectionTypeHTTP,
+		BaseURL:   "https://api.example.com",
+		Headers:   "Authorization=Bearer token,X-Env=prod",
+		IfHeaders: "X-Scope=demo",
+		IfQueries: "inject=true",
 	})
 	if err != nil {
 		t.Fatalf("buildInjectionSpec() error = %v", err)
@@ -46,6 +48,12 @@ func TestBuildInjectionSpecHTTP(t *testing.T) {
 	}
 	if spec.HTTP.Headers == nil || len(*spec.HTTP.Headers) != 2 {
 		t.Fatalf("HTTP headers = %v, want 2 headers", spec.HTTP.Headers)
+	}
+	if spec.HTTP.IfHeaders == nil || (*spec.HTTP.IfHeaders)["X-Scope"] != "demo" {
+		t.Fatalf("HTTP if headers = %v, want X-Scope=demo", spec.HTTP.IfHeaders)
+	}
+	if spec.HTTP.IfQueries == nil || (*spec.HTTP.IfQueries)["inject"] != "true" {
+		t.Fatalf("HTTP if queries = %v, want inject=true", spec.HTTP.IfQueries)
 	}
 }
 
@@ -91,10 +99,14 @@ func TestFormatInjectionSummaryHTTP(t *testing.T) {
 		"Authorization": "Bearer token",
 		"X-Trace":       "true",
 	}
+	ifHeaders := map[string]string{"X-Scope": "demo"}
+	ifQueries := map[string]string{"inject": "true"}
 	spec := sandbox.InjectionSpec{
 		HTTP: &sandbox.HTTPInjection{
-			BaseURL: "https://api.example.com",
-			Headers: &headers,
+			BaseURL:   "https://api.example.com",
+			Headers:   &headers,
+			IfHeaders: &ifHeaders,
+			IfQueries: &ifQueries,
 		},
 	}
 
@@ -107,6 +119,9 @@ func TestFormatInjectionSummaryHTTP(t *testing.T) {
 	got := formatInjectionHeaders(spec)
 	if got != "Authorization, X-Trace" && got != "X-Trace, Authorization" {
 		t.Fatalf("formatInjectionHeaders() = %q, want header key list", got)
+	}
+	if got := formatInjectionConditions(spec); got != "headers: X-Scope; queries: inject" {
+		t.Fatalf("formatInjectionConditions() = %q, want condition key list", got)
 	}
 }
 
@@ -133,15 +148,16 @@ func TestFormatInjectionTargetQiniuDefault(t *testing.T) {
 
 func TestFormatInjectionSummaryGithub(t *testing.T) {
 	token := "ghp-token"
+	baseURL := "https://api.github.com/repos/qiniu/*"
 	spec := sandbox.InjectionSpec{
-		Github: &sandbox.GithubInjection{Token: &token},
+		Github: &sandbox.GithubInjection{BaseURL: &baseURL, Token: &token},
 	}
 
 	if got := formatInjectionType(spec); got != "github" {
 		t.Fatalf("formatInjectionType() = %q, want %q", got, "github")
 	}
-	if got := formatInjectionTarget(spec); got != "github.com, api.github.com" {
-		t.Fatalf("formatInjectionTarget() = %q, want %q", got, "github.com, api.github.com")
+	if got := formatInjectionTarget(spec); got != "https://api.github.com/repos/qiniu/*" {
+		t.Fatalf("formatInjectionTarget() = %q, want %q", got, "https://api.github.com/repos/qiniu/*")
 	}
 	if got := formatInjectionHeaders(spec); got != "-" {
 		t.Fatalf("formatInjectionHeaders() = %q, want %q", got, "-")
@@ -153,8 +169,10 @@ func TestFormatInjectionSummaryGithub(t *testing.T) {
 
 func TestBuildInjectionSpecGithub(t *testing.T) {
 	spec, err := buildInjectionSpec(injectionInput{
-		Type:   injectionTypeGithub,
-		APIKey: "ghp-token",
+		Type:      injectionTypeGithub,
+		APIKey:    "ghp-token",
+		BaseURL:   "https://api.github.com/repos/qiniu/*",
+		IfHeaders: "X-GitHub-Api-Version=2022-11-28",
 	})
 	if err != nil {
 		t.Fatalf("buildInjectionSpec(github) error = %v", err)
@@ -164,6 +182,12 @@ func TestBuildInjectionSpecGithub(t *testing.T) {
 	}
 	if spec.Github.Token == nil || *spec.Github.Token != "ghp-token" {
 		t.Fatalf("Github token = %v, want %q", spec.Github.Token, "ghp-token")
+	}
+	if spec.Github.BaseURL == nil || *spec.Github.BaseURL != "https://api.github.com/repos/qiniu/*" {
+		t.Fatalf("Github base URL = %v, want https://api.github.com/repos/qiniu/*", spec.Github.BaseURL)
+	}
+	if spec.Github.IfHeaders == nil || (*spec.Github.IfHeaders)["X-GitHub-Api-Version"] != "2022-11-28" {
+		t.Fatalf("Github if headers = %v, want version header", spec.Github.IfHeaders)
 	}
 }
 
@@ -183,6 +207,9 @@ func TestShouldUpdateInjection(t *testing.T) {
 	}
 	if !shouldUpdateInjection(injectionInput{APIKey: "sk"}) {
 		t.Fatal("shouldUpdateInjection() = false, want true when api key is set")
+	}
+	if !shouldUpdateInjection(injectionInput{IfHeaders: "X-Scope=demo"}) {
+		t.Fatal("shouldUpdateInjection() = false, want true when if headers are set")
 	}
 }
 

--- a/iqshell/sandbox/injection_rule/operations/list.go
+++ b/iqshell/sandbox/injection_rule/operations/list.go
@@ -38,14 +38,15 @@ func List(info ListInfo) {
 	}
 
 	tw := sbClient.NewTable(os.Stdout)
-	fmt.Fprintf(tw, "RULE ID\tNAME\tTYPE\tTARGET\tHEADERS\tCREATED AT\tUPDATED AT\n")
+	fmt.Fprintf(tw, "RULE ID\tNAME\tTYPE\tTARGET\tHEADERS\tCONDITIONS\tCREATED AT\tUPDATED AT\n")
 	for _, r := range rules {
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 			r.RuleID,
 			r.Name,
 			formatInjectionType(r.Injection),
 			formatInjectionTarget(r.Injection),
 			formatInjectionHeaders(r.Injection),
+			formatInjectionConditions(r.Injection),
 			sbClient.FormatTimestamp(r.CreatedAt),
 			sbClient.FormatTimestamp(r.UpdatedAt),
 		)

--- a/iqshell/sandbox/injection_rule/operations/update.go
+++ b/iqshell/sandbox/injection_rule/operations/update.go
@@ -10,12 +10,14 @@ import (
 
 // UpdateInfo holds parameters for updating an injection rule.
 type UpdateInfo struct {
-	RuleID  string
-	Name    string
-	Type    string
-	APIKey  string
-	BaseURL string
-	Headers string
+	RuleID    string
+	Name      string
+	Type      string
+	APIKey    string
+	BaseURL   string
+	Headers   string
+	IfHeaders string
+	IfQueries string
 }
 
 // Update updates an existing injection rule.
@@ -26,14 +28,16 @@ func Update(info UpdateInfo) {
 	}
 
 	input := injectionInput{
-		Type:    info.Type,
-		APIKey:  info.APIKey,
-		BaseURL: info.BaseURL,
-		Headers: info.Headers,
+		Type:      info.Type,
+		APIKey:    info.APIKey,
+		BaseURL:   info.BaseURL,
+		Headers:   info.Headers,
+		IfHeaders: info.IfHeaders,
+		IfQueries: info.IfQueries,
 	}
 
 	if info.Name == "" && !shouldUpdateInjection(input) {
-		sbClient.PrintError("at least one of --name, --type, --api-key, --base-url, or --headers is required")
+		sbClient.PrintError("at least one of --name, --type, --api-key, --base-url, --headers, --if-headers, or --if-queries is required")
 		return
 	}
 

--- a/iqshell/sandbox/injection_rule_integration_test.go
+++ b/iqshell/sandbox/injection_rule_integration_test.go
@@ -1,0 +1,145 @@
+//go:build integration
+
+package sandbox
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/qiniu/go-sdk/v7/sandbox"
+)
+
+func testInjectionRuleClient(t *testing.T) *sandbox.Client {
+	t.Helper()
+	client, err := NewInjectionRuleClient()
+	if err != nil {
+		t.Skipf("injection rule client not available: %v", err)
+	}
+	return client
+}
+
+func TestIntegrationInjectionRuleMatchConditionsAndGithubBaseURL(t *testing.T) {
+	client := testInjectionRuleClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	name := fmt.Sprintf("qshell-int-v72614-%d", time.Now().UnixNano())
+	headers := map[string]string{"Authorization": "Bearer integration-test"}
+	ifHeaders := map[string]string{"X-Qshell-Integration": "v7.26.14"}
+	ifQueries := map[string]string{"inject": "true"}
+
+	rule, err := client.CreateInjectionRule(ctx, sandbox.CreateInjectionRuleParams{
+		Name: name,
+		Injection: sandbox.InjectionSpec{
+			HTTP: &sandbox.HTTPInjection{
+				BaseURL:   "https://httpbin.org/v1/*",
+				Headers:   &headers,
+				IfHeaders: &ifHeaders,
+				IfQueries: &ifQueries,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateInjectionRule with HTTP match conditions failed: %v", err)
+	}
+	t.Logf("created injection rule %s", rule.RuleID)
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cleanupCancel()
+		if err := client.DeleteInjectionRule(cleanupCtx, rule.RuleID); err != nil {
+			t.Logf("cleanup injection rule %s failed: %v", rule.RuleID, err)
+		}
+	})
+
+	got, err := client.GetInjectionRule(ctx, rule.RuleID)
+	if err != nil {
+		t.Fatalf("GetInjectionRule after create failed: %v", err)
+	}
+	assertIntegrationHTTPInjection(t, got.Injection, headers, ifHeaders, ifQueries)
+
+	githubToken := "ghp_qshell_integration_test"
+	githubBaseURL := "https://api.github.com/repos/qiniu/*"
+	githubIfHeaders := map[string]string{"X-GitHub-Api-Version": "2022-11-28"}
+	githubIfQueries := map[string]string{"per_page": "100"}
+
+	updated, err := client.UpdateInjectionRule(ctx, rule.RuleID, sandbox.UpdateInjectionRuleParams{
+		Injection: &sandbox.InjectionSpec{
+			Github: &sandbox.GithubInjection{
+				BaseURL:   &githubBaseURL,
+				IfHeaders: &githubIfHeaders,
+				IfQueries: &githubIfQueries,
+				Token:     &githubToken,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("UpdateInjectionRule with GitHub base URL and match conditions failed: %v", err)
+	}
+	assertIntegrationGithubInjection(t, updated.Injection, githubBaseURL, githubIfHeaders, githubIfQueries)
+
+	got, err = client.GetInjectionRule(ctx, rule.RuleID)
+	if err != nil {
+		t.Fatalf("GetInjectionRule after update failed: %v", err)
+	}
+	assertIntegrationGithubInjection(t, got.Injection, githubBaseURL, githubIfHeaders, githubIfQueries)
+
+	rules, err := client.ListInjectionRules(ctx)
+	if err != nil {
+		t.Fatalf("ListInjectionRules failed: %v", err)
+	}
+	found := false
+	for _, candidate := range rules {
+		if candidate.RuleID == rule.RuleID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("created injection rule %s not found in list response", rule.RuleID)
+	}
+}
+
+func assertIntegrationHTTPInjection(t *testing.T, spec sandbox.InjectionSpec, headers, ifHeaders, ifQueries map[string]string) {
+	t.Helper()
+	if spec.HTTP == nil {
+		t.Fatalf("HTTP injection is nil: %+v", spec)
+	}
+	if spec.HTTP.BaseURL != "https://httpbin.org/v1/*" {
+		t.Fatalf("HTTP base URL = %q, want https://httpbin.org/v1/*", spec.HTTP.BaseURL)
+	}
+	assertStringMapPtrEqual(t, "HTTP headers", spec.HTTP.Headers, headers)
+	assertStringMapPtrEqual(t, "HTTP if headers", spec.HTTP.IfHeaders, ifHeaders)
+	assertStringMapPtrEqual(t, "HTTP if queries", spec.HTTP.IfQueries, ifQueries)
+}
+
+func assertIntegrationGithubInjection(t *testing.T, spec sandbox.InjectionSpec, baseURL string, ifHeaders, ifQueries map[string]string) {
+	t.Helper()
+	if spec.Github == nil {
+		t.Fatalf("GitHub injection is nil: %+v", spec)
+	}
+	if spec.Github.BaseURL == nil || *spec.Github.BaseURL != baseURL {
+		t.Fatalf("GitHub base URL = %v, want %q", spec.Github.BaseURL, baseURL)
+	}
+	assertStringMapPtrEqual(t, "GitHub if headers", spec.Github.IfHeaders, ifHeaders)
+	assertStringMapPtrEqual(t, "GitHub if queries", spec.Github.IfQueries, ifQueries)
+	if spec.Github.Token == nil || *spec.Github.Token == "" {
+		t.Fatal("GitHub token was not returned as configured")
+	}
+}
+
+func assertStringMapPtrEqual(t *testing.T, label string, got *map[string]string, want map[string]string) {
+	t.Helper()
+	if got == nil {
+		t.Fatalf("%s = nil, want %v", label, want)
+	}
+	if len(*got) != len(want) {
+		t.Fatalf("%s len = %d, want %d: %v", label, len(*got), len(want), *got)
+	}
+	for key, wantValue := range want {
+		if gotValue := (*got)[key]; gotValue != wantValue {
+			t.Fatalf("%s[%q] = %q, want %q", label, key, gotValue, wantValue)
+		}
+	}
+}

--- a/iqshell/sandbox/sandbox/operations/create.go
+++ b/iqshell/sandbox/sandbox/operations/create.go
@@ -138,7 +138,14 @@ func buildSandboxInjections(ruleIDs, inlineSpecs []string) ([]sandbox.SandboxInj
 
 func parseInlineSandboxInjection(spec string) (sandbox.SandboxInjectionSpec, error) {
 	fields := parseInlineInjectionFields(spec)
-	parts, err := sbClient.BuildInjectionParts(fields["type"], fields["api-key"], fields["base-url"], parseInlineHeaders(fields["headers"]))
+	parts, err := sbClient.BuildInjectionParts(
+		fields["type"],
+		fields["api-key"],
+		fields["base-url"],
+		parseInlineHeaders(fields["headers"]),
+		parseInlineHeaders(fields["if-headers"]),
+		parseInlineHeaders(fields["if-queries"]),
+	)
 	if err != nil {
 		return sandbox.SandboxInjectionSpec{}, fmt.Errorf("invalid inline injection spec: %w", err)
 	}
@@ -153,21 +160,14 @@ func parseInlineSandboxInjection(spec string) (sandbox.SandboxInjectionSpec, err
 }
 
 func parseInlineInjectionFields(spec string) map[string]string {
-	const headersKey = "headers="
-
 	fields := make(map[string]string)
-	headersSpec := ""
-	if idx := strings.Index(spec, ","+headersKey); idx >= 0 {
-		headersSpec = spec[idx+len(","+headersKey):]
-		spec = spec[:idx]
-	}
-	if strings.HasPrefix(spec, headersKey) {
-		headersSpec = spec[len(headersKey):]
-		spec = ""
-	}
+	currentKey := ""
 	for _, part := range strings.Split(spec, ",") {
 		key, value, ok := strings.Cut(part, "=")
 		if !ok {
+			if currentKey != "" && fields[currentKey] != "" {
+				fields[currentKey] += "," + strings.TrimSpace(part)
+			}
 			continue
 		}
 		key = strings.TrimSpace(key)
@@ -175,12 +175,34 @@ func parseInlineInjectionFields(spec string) map[string]string {
 		if key == "" || value == "" {
 			continue
 		}
+		if !isInlineInjectionFieldKey(key) {
+			if isInlineInjectionMapField(currentKey) {
+				fields[currentKey] += "," + strings.TrimSpace(part)
+			}
+			continue
+		}
 		fields[key] = value
-	}
-	if strings.TrimSpace(headersSpec) != "" {
-		fields["headers"] = headersSpec
+		currentKey = key
 	}
 	return fields
+}
+
+func isInlineInjectionMapField(key string) bool {
+	switch key {
+	case "headers", "if-headers", "if-queries":
+		return true
+	default:
+		return false
+	}
+}
+
+func isInlineInjectionFieldKey(key string) bool {
+	switch key {
+	case "type", "api-key", "base-url", "headers", "if-headers", "if-queries":
+		return true
+	default:
+		return false
+	}
 }
 
 // buildSandboxResources 把命令行传入的 --resource 规约转换为 SDK 的资源列表。

--- a/iqshell/sandbox/sandbox/operations/create.go
+++ b/iqshell/sandbox/sandbox/operations/create.go
@@ -165,8 +165,9 @@ func parseInlineInjectionFields(spec string) map[string]string {
 	for _, part := range strings.Split(spec, ",") {
 		key, value, ok := strings.Cut(part, "=")
 		if !ok {
-			if currentKey != "" && fields[currentKey] != "" {
-				fields[currentKey] += "," + strings.TrimSpace(part)
+			trimmed := strings.TrimSpace(part)
+			if trimmed != "" && isInlineInjectionMapField(currentKey) && fields[currentKey] != "" {
+				fields[currentKey] += "," + trimmed
 			}
 			continue
 		}

--- a/iqshell/sandbox/sandbox/operations/create_test.go
+++ b/iqshell/sandbox/sandbox/operations/create_test.go
@@ -55,7 +55,7 @@ func TestBuildSandboxInjections_WithInlineOpenAI(t *testing.T) {
 }
 
 func TestBuildSandboxInjections_WithInlineHTTP(t *testing.T) {
-	injections, err := buildSandboxInjections(nil, []string{"type=http,base-url=https://api.example.com,headers=Authorization=Bearer token;X-Env=prod"})
+	injections, err := buildSandboxInjections(nil, []string{"type=http,base-url=https://api.example.com,headers=Authorization=Bearer token;X-Env=prod,if-headers=X-Scope=demo,if-queries=inject=true"})
 	if err != nil {
 		t.Fatalf("buildSandboxInjections() error = %v", err)
 	}
@@ -67,6 +67,12 @@ func TestBuildSandboxInjections_WithInlineHTTP(t *testing.T) {
 	}
 	if injections[0].HTTP.Headers == nil || len(*injections[0].HTTP.Headers) != 2 {
 		t.Fatalf("http headers = %v, want 2 headers", injections[0].HTTP.Headers)
+	}
+	if injections[0].HTTP.IfHeaders == nil || (*injections[0].HTTP.IfHeaders)["X-Scope"] != "demo" {
+		t.Fatalf("http if headers = %v, want X-Scope=demo", injections[0].HTTP.IfHeaders)
+	}
+	if injections[0].HTTP.IfQueries == nil || (*injections[0].HTTP.IfQueries)["inject"] != "true" {
+		t.Fatalf("http if queries = %v, want inject=true", injections[0].HTTP.IfQueries)
 	}
 }
 
@@ -131,12 +137,41 @@ func TestParseInlineInjectionFields_HeadersOnly(t *testing.T) {
 }
 
 func TestParseInlineInjectionFields_HeadersWithOtherFields(t *testing.T) {
-	fields := parseInlineInjectionFields("type=http,base-url=https://api.example.com,headers=Authorization=Bearer token;X-Env=prod")
+	fields := parseInlineInjectionFields("type=http,base-url=https://api.example.com,headers=Authorization=Bearer token;X-Env=prod,if-headers=X-Scope=demo,if-queries=inject=true")
 	if fields["type"] != "http" || fields["base-url"] != "https://api.example.com" {
 		t.Fatalf("fields = %v, want type and base-url parsed", fields)
 	}
 	if got := fields["headers"]; got != "Authorization=Bearer token;X-Env=prod" {
 		t.Fatalf("headers = %q, want %q", got, "Authorization=Bearer token;X-Env=prod")
+	}
+	if got := fields["if-headers"]; got != "X-Scope=demo" {
+		t.Fatalf("if-headers = %q, want %q", got, "X-Scope=demo")
+	}
+	if got := fields["if-queries"]; got != "inject=true" {
+		t.Fatalf("if-queries = %q, want %q", got, "inject=true")
+	}
+}
+
+func TestParseInlineInjectionFields_CommaSeparatedHeadersWithFollowingCondition(t *testing.T) {
+	fields := parseInlineInjectionFields("type=http,base-url=https://api.example.com,headers=Authorization=Bearer token,X-Env=prod,if-headers=X-Scope=demo")
+	if got := fields["headers"]; got != "Authorization=Bearer token,X-Env=prod" {
+		t.Fatalf("headers = %q, want %q", got, "Authorization=Bearer token,X-Env=prod")
+	}
+	if got := fields["if-headers"]; got != "X-Scope=demo" {
+		t.Fatalf("if-headers = %q, want %q", got, "X-Scope=demo")
+	}
+}
+
+func TestParseInlineInjectionFields_UnknownKeyDoesNotPolluteScalarField(t *testing.T) {
+	fields := parseInlineInjectionFields("type=http,unknown=value,base-url=https://api.example.com")
+	if got := fields["type"]; got != "http" {
+		t.Fatalf("type = %q, want %q", got, "http")
+	}
+	if got := fields["base-url"]; got != "https://api.example.com" {
+		t.Fatalf("base-url = %q, want %q", got, "https://api.example.com")
+	}
+	if _, ok := fields["unknown"]; ok {
+		t.Fatalf("unknown field should be ignored, got fields=%v", fields)
 	}
 }
 

--- a/iqshell/sandbox/sandbox/operations/create_test.go
+++ b/iqshell/sandbox/sandbox/operations/create_test.go
@@ -175,6 +175,13 @@ func TestParseInlineInjectionFields_UnknownKeyDoesNotPolluteScalarField(t *testi
 	}
 }
 
+func TestParseInlineInjectionFields_TrailingCommaDoesNotPolluteScalarField(t *testing.T) {
+	fields := parseInlineInjectionFields("type=http,")
+	if got := fields["type"]; got != "http" {
+		t.Fatalf("type = %q, want %q", got, "http")
+	}
+}
+
 func TestParseInlineHeaders_SemicolonSeparated(t *testing.T) {
 	headers := parseInlineHeaders("Authorization=Bearer token;X-Env=prod")
 	if len(headers) != 2 {

--- a/iqshell/sandbox/utils.go
+++ b/iqshell/sandbox/utils.go
@@ -105,27 +105,33 @@ type InjectionParts struct {
 const supportedInjectionTypes = "openai, anthropic, gemini, qiniu, github, http"
 
 // BuildInjectionParts builds a provider-specific injection payload from the given inputs.
-func BuildInjectionParts(typ, apiKey, baseURL string, headers map[string]string) (InjectionParts, error) {
+func BuildInjectionParts(typ, apiKey, baseURL string, headers, ifHeaders, ifQueries map[string]string) (InjectionParts, error) {
 	switch strings.ToLower(strings.TrimSpace(typ)) {
 	case "openai":
 		return InjectionParts{
 			OpenAI: &sdkSandbox.OpenAIInjection{
-				APIKey:  optionalString(apiKey),
-				BaseURL: optionalString(baseURL),
+				APIKey:    optionalString(apiKey),
+				BaseURL:   optionalString(baseURL),
+				IfHeaders: optionalMap(ifHeaders),
+				IfQueries: optionalMap(ifQueries),
 			},
 		}, nil
 	case "anthropic":
 		return InjectionParts{
 			Anthropic: &sdkSandbox.AnthropicInjection{
-				APIKey:  optionalString(apiKey),
-				BaseURL: optionalString(baseURL),
+				APIKey:    optionalString(apiKey),
+				BaseURL:   optionalString(baseURL),
+				IfHeaders: optionalMap(ifHeaders),
+				IfQueries: optionalMap(ifQueries),
 			},
 		}, nil
 	case "gemini":
 		return InjectionParts{
 			Gemini: &sdkSandbox.GeminiInjection{
-				APIKey:  optionalString(apiKey),
-				BaseURL: optionalString(baseURL),
+				APIKey:    optionalString(apiKey),
+				BaseURL:   optionalString(baseURL),
+				IfHeaders: optionalMap(ifHeaders),
+				IfQueries: optionalMap(ifQueries),
 			},
 		}, nil
 	case "qiniu":
@@ -135,15 +141,16 @@ func BuildInjectionParts(typ, apiKey, baseURL string, headers map[string]string)
 		}
 		return InjectionParts{
 			Qiniu: &sdkSandbox.QiniuInjection{
-				APIKey:  optionalString(apiKey),
-				BaseURL: optionalString(validatedBaseURL),
+				APIKey:    optionalString(apiKey),
+				BaseURL:   optionalString(validatedBaseURL),
+				IfHeaders: optionalMap(ifHeaders),
+				IfQueries: optionalMap(ifQueries),
 			},
 		}, nil
 	case "github":
-		// GitHub 注入仅接受 token（经 api-key 字段承载），目标固定为 github.com / api.github.com；
-		// 显式拒绝 base-url / headers，避免 typo 看起来配置成功却被静默丢弃
-		if strings.TrimSpace(baseURL) != "" {
-			return InjectionParts{}, fmt.Errorf("base URL is not supported for injection type github; target is fixed to github.com / api.github.com")
+		validatedBaseURL, err := validateGithubBaseURL(baseURL)
+		if err != nil {
+			return InjectionParts{}, err
 		}
 		if len(headers) > 0 {
 			return InjectionParts{}, fmt.Errorf("headers are not supported for injection type github")
@@ -154,7 +161,10 @@ func BuildInjectionParts(typ, apiKey, baseURL string, headers map[string]string)
 		}
 		return InjectionParts{
 			Github: &sdkSandbox.GithubInjection{
-				Token: optionalString(apiKey),
+				BaseURL:   optionalString(validatedBaseURL),
+				IfHeaders: optionalMap(ifHeaders),
+				IfQueries: optionalMap(ifQueries),
+				Token:     optionalString(apiKey),
 			},
 		}, nil
 	case "http":
@@ -168,12 +178,30 @@ func BuildInjectionParts(typ, apiKey, baseURL string, headers map[string]string)
 		if len(headers) > 0 {
 			httpInjection.Headers = &headers
 		}
+		httpInjection.IfHeaders = optionalMap(ifHeaders)
+		httpInjection.IfQueries = optionalMap(ifQueries)
 		return InjectionParts{HTTP: httpInjection}, nil
 	case "":
 		return InjectionParts{}, fmt.Errorf("injection type is required and must be one of: %s", supportedInjectionTypes)
 	default:
 		return InjectionParts{}, fmt.Errorf("unsupported injection type %q, must be one of: %s", typ, supportedInjectionTypes)
 	}
+}
+
+func validateGithubBaseURL(baseURL string) (string, error) {
+	trimmedBaseURL := strings.TrimSpace(baseURL)
+	if trimmedBaseURL == "" {
+		return "", nil
+	}
+	if _, err := validateBaseURL(trimmedBaseURL, false); err != nil {
+		return "", err
+	}
+	parsedURL, _ := url.Parse(trimmedBaseURL)
+	host := strings.ToLower(parsedURL.Hostname())
+	if host != "github.com" && host != "api.github.com" {
+		return "", fmt.Errorf("base URL for injection type github must use github.com or api.github.com")
+	}
+	return trimmedBaseURL, nil
 }
 
 func validateBaseURL(baseURL string, required bool) (string, error) {
@@ -197,6 +225,13 @@ func optionalString(value string) *string {
 		return nil
 	}
 	return &trimmed
+}
+
+func optionalMap(value map[string]string) *map[string]string {
+	if len(value) == 0 {
+		return nil
+	}
+	return &value
 }
 
 // logLevelOrder maps log levels to numeric order for hierarchical filtering.

--- a/iqshell/sandbox/utils_test.go
+++ b/iqshell/sandbox/utils_test.go
@@ -360,7 +360,7 @@ func TestParseMetadataMap_MixedPairs(t *testing.T) {
 // === BuildInjectionParts tests ===
 
 func TestBuildInjectionParts_Qiniu(t *testing.T) {
-	parts, err := BuildInjectionParts("qiniu", "sk-qiniu", " https://api.qnaigc.com ", nil)
+	parts, err := BuildInjectionParts("qiniu", "sk-qiniu", " https://api.qnaigc.com ", nil, nil, nil)
 	if err != nil {
 		t.Fatalf("BuildInjectionParts(qiniu) error = %v", err)
 	}
@@ -377,7 +377,7 @@ func TestBuildInjectionParts_Qiniu(t *testing.T) {
 
 func TestBuildInjectionParts_HTTPWithHeaders(t *testing.T) {
 	headers := map[string]string{"Authorization": "Bearer token"}
-	parts, err := BuildInjectionParts("http", "", "https://api.example.com", headers)
+	parts, err := BuildInjectionParts("http", "", "https://api.example.com", headers, nil, nil)
 	if err != nil {
 		t.Fatalf("BuildInjectionParts(http) error = %v", err)
 	}
@@ -390,31 +390,31 @@ func TestBuildInjectionParts_HTTPWithHeaders(t *testing.T) {
 }
 
 func TestBuildInjectionParts_HTTPRejectsInvalidURL(t *testing.T) {
-	if _, err := BuildInjectionParts("http", "", "file:///tmp/a", nil); err == nil {
+	if _, err := BuildInjectionParts("http", "", "file:///tmp/a", nil, nil, nil); err == nil {
 		t.Fatal("BuildInjectionParts(http invalid url) expected error, got nil")
 	}
 }
 
 func TestBuildInjectionParts_QiniuRejectsInvalidURL(t *testing.T) {
-	if _, err := BuildInjectionParts("qiniu", "", "file:///tmp/a", nil); err == nil {
+	if _, err := BuildInjectionParts("qiniu", "", "file:///tmp/a", nil, nil, nil); err == nil {
 		t.Fatal("BuildInjectionParts(qiniu invalid url) expected error, got nil")
 	}
 }
 
 func TestBuildInjectionParts_RejectsMissingType(t *testing.T) {
-	if _, err := BuildInjectionParts("", "", "", nil); err == nil {
+	if _, err := BuildInjectionParts("", "", "", nil, nil, nil); err == nil {
 		t.Fatal("BuildInjectionParts(missing type) expected error, got nil")
 	}
 }
 
 func TestBuildInjectionParts_RejectsUnknownType(t *testing.T) {
-	if _, err := BuildInjectionParts("unknown", "", "", nil); err == nil {
+	if _, err := BuildInjectionParts("unknown", "", "", nil, nil, nil); err == nil {
 		t.Fatal("BuildInjectionParts(unknown type) expected error, got nil")
 	}
 }
 
 func TestBuildInjectionParts_OpenAIEmptyOptionalFields(t *testing.T) {
-	parts, err := BuildInjectionParts("openai", "", "", nil)
+	parts, err := BuildInjectionParts("openai", "", "", nil, nil, nil)
 	if err != nil {
 		t.Fatalf("BuildInjectionParts(openai) error = %v", err)
 	}
@@ -427,7 +427,7 @@ func TestBuildInjectionParts_OpenAIEmptyOptionalFields(t *testing.T) {
 }
 
 func TestBuildInjectionParts_QiniuEmptyOptionalFields(t *testing.T) {
-	parts, err := BuildInjectionParts("qiniu", "", "", nil)
+	parts, err := BuildInjectionParts("qiniu", "", "", nil, nil, nil)
 	if err != nil {
 		t.Fatalf("BuildInjectionParts(qiniu) error = %v", err)
 	}
@@ -440,7 +440,7 @@ func TestBuildInjectionParts_QiniuEmptyOptionalFields(t *testing.T) {
 }
 
 func TestBuildInjectionParts_Github(t *testing.T) {
-	parts, err := BuildInjectionParts("github", " ghp-token ", "", nil)
+	parts, err := BuildInjectionParts("github", " ghp-token ", "", nil, nil, nil)
 	if err != nil {
 		t.Fatalf("BuildInjectionParts(github) error = %v", err)
 	}
@@ -453,22 +453,50 @@ func TestBuildInjectionParts_Github(t *testing.T) {
 }
 
 func TestBuildInjectionParts_GithubEmptyToken(t *testing.T) {
-	if _, err := BuildInjectionParts("github", "", "", nil); err == nil {
+	if _, err := BuildInjectionParts("github", "", "", nil, nil, nil); err == nil {
 		t.Fatal("expected BuildInjectionParts(github) without token to fail")
 	}
-	if _, err := BuildInjectionParts("github", "   ", "", nil); err == nil {
+	if _, err := BuildInjectionParts("github", "   ", "", nil, nil, nil); err == nil {
 		t.Fatal("expected BuildInjectionParts(github) with whitespace-only token to fail")
 	}
 }
 
-func TestBuildInjectionParts_GithubRejectsBaseURL(t *testing.T) {
-	if _, err := BuildInjectionParts("github", "ghp-x", "https://api.github.com", nil); err == nil {
-		t.Fatal("expected BuildInjectionParts(github, base-url) to fail")
+func TestBuildInjectionParts_GithubBaseURL(t *testing.T) {
+	parts, err := BuildInjectionParts("github", "ghp-x", "https://api.github.com/repos/qiniu/*", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("BuildInjectionParts(github, base-url) error = %v", err)
+	}
+	if parts.Github.BaseURL == nil || *parts.Github.BaseURL != "https://api.github.com/repos/qiniu/*" {
+		t.Fatalf("github base URL = %v, want https://api.github.com/repos/qiniu/*", parts.Github.BaseURL)
+	}
+}
+
+func TestBuildInjectionParts_GithubRejectsUnsupportedBaseURLHost(t *testing.T) {
+	if _, err := BuildInjectionParts("github", "ghp-x", "https://git.example.com", nil, nil, nil); err == nil {
+		t.Fatal("expected BuildInjectionParts(github, unsupported base-url host) to fail")
 	}
 }
 
 func TestBuildInjectionParts_GithubRejectsHeaders(t *testing.T) {
-	if _, err := BuildInjectionParts("github", "ghp-x", "", map[string]string{"X": "y"}); err == nil {
+	if _, err := BuildInjectionParts("github", "ghp-x", "", map[string]string{"X": "y"}, nil, nil); err == nil {
 		t.Fatal("expected BuildInjectionParts(github, headers) to fail")
+	}
+}
+
+func TestBuildInjectionParts_HTTPWithMatchConditions(t *testing.T) {
+	ifHeaders := map[string]string{"X-Env": "prod"}
+	ifQueries := map[string]string{"inject": "true"}
+	parts, err := BuildInjectionParts("http", "", "https://api.example.com/v1/*", nil, ifHeaders, ifQueries)
+	if err != nil {
+		t.Fatalf("BuildInjectionParts(http, conditions) error = %v", err)
+	}
+	if parts.HTTP == nil {
+		t.Fatal("BuildInjectionParts(http, conditions) did not build http injection")
+	}
+	if parts.HTTP.IfHeaders == nil || (*parts.HTTP.IfHeaders)["X-Env"] != "prod" {
+		t.Fatalf("http if headers = %v, want X-Env=prod", parts.HTTP.IfHeaders)
+	}
+	if parts.HTTP.IfQueries == nil || (*parts.HTTP.IfQueries)["inject"] != "true" {
+		t.Fatalf("http if queries = %v, want inject=true", parts.HTTP.IfQueries)
 	}
 }


### PR DESCRIPTION
## 变更内容

- 升级 `github.com/qiniu/go-sdk/v7` 到 `v7.26.14`
- `sandbox injection-rule create/update` 新增 `--if-headers` 与 `--if-queries`
- `sandbox create --inline-injection` 支持 `if-headers=` / `if-queries=`
- `github` 注入类型支持通过 `--base-url` / `base-url=` 限制匹配范围
- `injection-rule list/get` 展示匹配条件
- 补充单元测试与真实远端 integration 测试

## 验证

- `gofmt -s -l .`
- `go test ./iqshell/sandbox/... ./cmd_test/...`
- `set -a; source .env.prod; set +a; make test-sandbox-integration`

说明：`make lint` 仍受仓库既有 staticcheck 问题影响，失败项不在本次变更文件中。

## Release 建议

建议合并后发布 `v2.19.9`，这是对 go-sdk `v7.26.14` 新 sandbox 能力的 CLI 跟进，包含用户可见的新参数与文档更新。