### PR TITLE
chore(deps): 升级 go-sdk 到 v7.26.15 修复 GetBucketInfo 空 ctime 解析错误

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.19.10 (2026-07-09)
+## 更新
+1. 升级 `github.com/qiniu/go-sdk/v7` 到 `v7.26.15`，修复 `BucketManager.GetBucketInfo` 在服务端未返回 `ctime` 字段时 `time.Parse(time.RFC3339, "")` 抛错的兼容性问题（返回 `parsing time "" as "2006-01-02T15:04:05Z07:00": cannot parse "" as "2006"`），同时 `BucketInfo.Ctime` 字段类型由 `int` 改为 `time.Time`，未返回时为零值
+
 # 2.19.9 (2026-06-30)
 ## 新增
 1. `qshell sandbox injection-rule create` / `update` 新增 `--if-headers` 与 `--if-queries` 参数，用于限制请求注入规则的匹配范围

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/fatih/color v1.18.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/muesli/termenv v0.16.0
-	github.com/qiniu/go-sdk/v7 v7.26.14
+	github.com/qiniu/go-sdk/v7 v7.26.15
 	github.com/schollz/progressbar/v3 v3.8.6
 	github.com/spf13/cast v1.3.1
 	github.com/spf13/cobra v1.1.3

--- a/go.sum
+++ b/go.sum
@@ -294,14 +294,8 @@ github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7z
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/qiniu/go-sdk/v7 v7.26.11 h1:XVGb5cgqYnNaExCirky+OntL1zvxRxBJuYoWMlnHOuE=
-github.com/qiniu/go-sdk/v7 v7.26.11/go.mod h1:ri7fGwbio0pRDFr8EK5TUpx0DbnpIMJ2bMSDxGWfCbk=
-github.com/qiniu/go-sdk/v7 v7.26.12 h1:AnWiKjBY62XpULoB/MySKdNmlUo9S9pQB7/0s7QueCo=
-github.com/qiniu/go-sdk/v7 v7.26.12/go.mod h1:ri7fGwbio0pRDFr8EK5TUpx0DbnpIMJ2bMSDxGWfCbk=
-github.com/qiniu/go-sdk/v7 v7.26.13 h1:U4usDKoLldAqJntLN4wv4pkAjwvM9dueOUY/wbbO/yM=
-github.com/qiniu/go-sdk/v7 v7.26.13/go.mod h1:ri7fGwbio0pRDFr8EK5TUpx0DbnpIMJ2bMSDxGWfCbk=
-github.com/qiniu/go-sdk/v7 v7.26.14 h1:kV9zdvTOM0w9/lgeYffDDw0Fj8FH14/XgCjk4Wb80k8=
-github.com/qiniu/go-sdk/v7 v7.26.14/go.mod h1:ri7fGwbio0pRDFr8EK5TUpx0DbnpIMJ2bMSDxGWfCbk=
+github.com/qiniu/go-sdk/v7 v7.26.15 h1:CaKVcP29ZnOp/pqE7U3RAZxqwL7CmtMTWlV1gAV71H0=
+github.com/qiniu/go-sdk/v7 v7.26.15/go.mod h1:ri7fGwbio0pRDFr8EK5TUpx0DbnpIMJ2bMSDxGWfCbk=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=

--- a/iqshell/common/flow/flow.go
+++ b/iqshell/common/flow/flow.go
@@ -128,7 +128,7 @@ func (f *Flow) Start() {
 
 			if workInfo == nil || workInfo.Work == nil {
 				if !hasMore {
-					log.Info("work producer get work completed")
+					log.Debug("work producer get work completed")
 					break
 				} else {
 					log.Info("work producer get work fail: work in empty")

--- a/iqshell/common/flow/flow.go
+++ b/iqshell/common/flow/flow.go
@@ -128,7 +128,7 @@ func (f *Flow) Start() {
 
 			if workInfo == nil || workInfo.Work == nil {
 				if !hasMore {
-					log.Debug("work producer get work completed")
+					log.Info("work producer get work completed")
 					break
 				} else {
 					log.Info("work producer get work fail: work in empty")


### PR DESCRIPTION
#### 变更背景描述

服务端在部分情况下返回的 `GetBucketInfo` 响应中 `ctime` 字段为空字符串，`go-sdk` 旧版本对该字段直接调用 `time.Parse(time.RFC3339, "")`，触发 `parsing time "" as "2006-01-02T15:04:05Z07:00": cannot parse "" as "2006"` 报错。

`qshell get` / `qdownload` / `qdownload2` 在 `info.IsPublic == false` 时会主动调用 `bucket.GetBucketInfo` 探测空间公私属性（`iqshell/storage/object/download/operations/download.go:57`），命中上述场景时下载直接失败并报 `get bucket info error: ...`。

#### jira issue链接

无

#### 主要变更点

- [x] fix bug
- [ ] new feature
- [ ] 不兼容变更

`go-sdk` v7.26.15 新增 `parseBucketCreatedAt` 助手对空字符串做容错（返回 `time.Time{}`），同时 `BucketInfo.Ctime` 字段类型由 `int` 改为 `time.Time`；qshell 仓库无任何代码直接使用该字段，运行时无感知。

#### 影响范围

- 所有调用 `qshell get` / `qdownload` / `qdownload2` 在 `info.IsPublic == false` 探测空间属性的命令
- 仅依赖升级间接生效，不修改 qshell 业务代码

#### Checklist

- [x] 已自测
- [ ] 已更新Readme